### PR TITLE
Add password-protected login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,17 @@ node bin/terminal-worktree.js --port 4000 --host 127.0.0.1 --ui path/to/file.htm
 - `-H, --host <host>`: Host/interface to bind (default: `0.0.0.0`).
 - `-u, --ui <path>`: Path to the UI HTML file to serve (default: `ui.sample.html`).
 - `-w, --workdir <path>`: Root directory that contains cloned repositories (default: current working directory).
+- `-P, --password <string>`: Password that guards the web UI (default: randomly generated at startup).
 - `-h, --help`: Display the usage information.
 - `-v, --version`: Print the package version.
+
+### Authentication
+
+Every time the server boots it prints the password that protects the web UI. If you do not provide
+one with `--password`, a secure 12-character password is generated and written to stdout alongside
+the usual startup logs. The browser prompts for this password before any repository APIs are
+available. Successful logins receive an HTTP-only session cookie; click **Log out** in the UI (or hit
+`POST /api/auth/logout`) to terminate the session and force the login screen to reappear.
 
 The server keeps running until you terminate the process (e.g. `Ctrl+C`). The mock UI loads React
 and supporting libraries from public CDNs, so make sure the machine running the browser has

--- a/ui.sample.html
+++ b/ui.sample.html
@@ -113,7 +113,135 @@
         );
       }
 
-      function RepoBrowser() {
+      function LoginScreen({ onAuthenticated }) {
+        const [password, setPassword] = useState('');
+        const [error, setError] = useState(null);
+        const [isSubmitting, setIsSubmitting] = useState(false);
+        const inputRef = useRef(null);
+
+        useEffect(() => {
+          if (inputRef.current) {
+            inputRef.current.focus();
+          }
+        }, []);
+
+        const handleSubmit = useCallback(
+          async (event) => {
+            event.preventDefault();
+            if (isSubmitting) {
+              return;
+            }
+            const trimmed = password.trim();
+            if (!trimmed) {
+              setError('Password is required.');
+              return;
+            }
+            setIsSubmitting(true);
+            setError(null);
+            try {
+              const response = await fetch('/api/auth/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify({ password: trimmed })
+              });
+              if (response.ok) {
+                setPassword('');
+                if (typeof onAuthenticated === 'function') {
+                  onAuthenticated();
+                }
+                return;
+              }
+              if (response.status === 401) {
+                setError('Incorrect password. Try again.');
+                return;
+              }
+              let message = 'Login failed. Please try again.';
+              try {
+                const data = await response.json();
+                if (data && typeof data.error === 'string') {
+                  message = data.error;
+                }
+              } catch {}
+              setError(message);
+            } catch {
+              setError('Unable to reach the server. Ensure terminal-worktree is running.');
+            } finally {
+              setIsSubmitting(false);
+            }
+          },
+          [isSubmitting, password, onAuthenticated]
+        );
+
+        return h(
+          'div',
+          {
+            className:
+              'min-h-screen bg-neutral-950 flex items-center justify-center px-4 text-neutral-100'
+          },
+          h(
+            'div',
+            {
+              className:
+                'w-full max-w-sm space-y-6 rounded-lg border border-neutral-800 bg-neutral-900/90 p-6 shadow-xl'
+            },
+            h(
+              'div',
+              { className: 'space-y-1' },
+              h('h1', { className: 'text-lg font-semibold text-neutral-50' }, 'terminal-worktree'),
+              h(
+                'p',
+                { className: 'text-sm text-neutral-400' },
+                'Enter the password printed by the CLI to continue.'
+              )
+            ),
+            h(
+              'form',
+              {
+                className: 'space-y-4',
+                onSubmit: handleSubmit
+              },
+              h(
+                'div',
+                { className: 'space-y-2' },
+                h(
+                  'label',
+                  { className: 'block text-xs uppercase tracking-wide text-neutral-400' },
+                  'Password'
+                ),
+                h('input', {
+                  ref: inputRef,
+                  type: 'password',
+                  value: password,
+                  onChange: (event) => {
+                    setPassword(event.target.value);
+                    if (error) {
+                      setError(null);
+                    }
+                  },
+                  autoComplete: 'current-password',
+                  placeholder: 'Paste password here',
+                  className:
+                    'w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-500/60'
+                })
+              ),
+              error ? h('p', { className: 'text-xs text-rose-300' }, error) : null,
+              h(
+                'button',
+                {
+                  type: 'submit',
+                  disabled: isSubmitting,
+                  className:
+                    'w-full inline-flex items-center justify-center gap-2 rounded-md bg-emerald-500/80 px-4 py-2 text-sm font-medium text-neutral-900 transition-colors hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-65'
+                },
+                isSubmitting ? 'Logging in…' : 'Log in'
+              )
+            )
+          )
+        );
+      }
+
+      function RepoBrowser({ onAuthExpired, onLogout, isLoggingOut } = {}) {
         const [width, setWidth] = useState(340);
         const [data, setData] = useState({});
         const [showAddRepoModal, setShowAddRepoModal] = useState(false);
@@ -131,6 +259,12 @@
         const [isCreatingWorktree, setIsCreatingWorktree] = useState(false);
         const [isDeletingWorktree, setIsDeletingWorktree] = useState(false);
         const [pendingActionLoading, setPendingActionLoading] = useState(null);
+
+        const notifyAuthExpired = useCallback(() => {
+          if (typeof onAuthExpired === 'function') {
+            onAuthExpired();
+          }
+        }, [onAuthExpired]);
 
         const renderSpinner = (colorClass = '') =>
           h(
@@ -192,7 +326,11 @@
 
         const refreshRepositories = useCallback(async () => {
           try {
-            const response = await fetch('/api/repos');
+            const response = await fetch('/api/repos', { credentials: 'include' });
+            if (response.status === 401) {
+              notifyAuthExpired();
+              return;
+            }
             if (!response.ok) {
               throw new Error(`Request failed with status ${response.status}`);
             }
@@ -213,7 +351,7 @@
           } catch (error) {
             console.error('Failed to load repositories', error);
           }
-        }, [applyDataUpdate]);
+        }, [applyDataUpdate, notifyAuthExpired]);
 
         useEffect(() => {
           refreshRepositories();
@@ -221,7 +359,11 @@
 
         const loadSessions = useCallback(async () => {
           try {
-            const response = await fetch('/api/sessions');
+            const response = await fetch('/api/sessions', { credentials: 'include' });
+            if (response.status === 401) {
+              notifyAuthExpired();
+              return;
+            }
             if (!response.ok) {
               throw new Error(`Request failed with status ${response.status}`);
             }
@@ -537,10 +679,15 @@
             const response = await fetch('/api/terminal/open', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
               body: JSON.stringify(
                 command ? { ...worktree, command } : worktree
               )
             });
+            if (response.status === 401) {
+              notifyAuthExpired();
+              throw new Error('AUTH_REQUIRED');
+            }
             if (!response.ok) {
               throw new Error(`Request failed with status ${response.status}`);
             }
@@ -571,7 +718,7 @@
             setTerminalStatus('error');
             throw error;
           }
-        }, [connectSocket, disposeSocket, disposeTerminal, setupTerminal, getWorktreeKey]);
+        }, [connectSocket, disposeSocket, disposeTerminal, setupTerminal, getWorktreeKey, notifyAuthExpired]);
 
         const handleAddRepo = async () => {
           if (isAddingRepo) {
@@ -587,8 +734,13 @@
             const response = await fetch('/api/repos', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
               body: JSON.stringify({ url: trimmed })
             });
+            if (response.status === 401) {
+              notifyAuthExpired();
+              return;
+            }
             if (!response.ok) {
               throw new Error(`Request failed with status ${response.status}`);
             }
@@ -640,8 +792,13 @@
             const response = await fetch('/api/worktrees', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
               body: JSON.stringify({ org, repo, branch: trimmedBranch })
             });
+            if (response.status === 401) {
+              notifyAuthExpired();
+              return;
+            }
             if (!response.ok) {
               throw new Error(`Request failed with status ${response.status}`);
             }
@@ -651,12 +808,15 @@
             const key = getWorktreeKey(org, repo, trimmedBranch);
             if (sessionMapRef.current.has(key) || knownSessionsRef.current.has(key)) {
               setActiveWorktree({ org, repo, branch: trimmedBranch });
-              try {
-                await openTerminalForWorktree({ org, repo, branch: trimmedBranch });
-                setPendingWorktreeAction(null);
-              } catch {
-                window.alert('Failed to reconnect to the existing session.');
+            try {
+              await openTerminalForWorktree({ org, repo, branch: trimmedBranch });
+              setPendingWorktreeAction(null);
+            } catch (error) {
+              if (error && error.message === 'AUTH_REQUIRED') {
+                return;
               }
+              window.alert('Failed to reconnect to the existing session.');
+            }
             } else {
               setPendingWorktreeAction({ org, repo, branch: trimmedBranch });
             }
@@ -681,8 +841,13 @@
             const response = await fetch('/api/worktrees', {
               method: 'DELETE',
               headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
               body: JSON.stringify({ org, repo, branch })
             });
+            if (response.status === 401) {
+              notifyAuthExpired();
+              return;
+            }
             if (!response.ok) {
               throw new Error(`Request failed with status ${response.status}`);
             }
@@ -727,7 +892,10 @@
             try {
               await openTerminalForWorktree(worktree);
               setPendingWorktreeAction(null);
-            } catch {
+            } catch (error) {
+              if (error && error.message === 'AUTH_REQUIRED') {
+                return;
+              }
               window.alert('Failed to reconnect to the existing session.');
             }
           } else {
@@ -754,6 +922,9 @@
             await openTerminalForWorktree(worktree, command ? { command } : {});
             setPendingWorktreeAction(null);
           } catch (error) {
+            if (error && error.message === 'AUTH_REQUIRED') {
+              return;
+            }
             console.error('Failed to launch terminal action', error);
             window.alert('Failed to launch the selected option. Check server logs for details.');
           } finally {
@@ -1026,8 +1197,31 @@
                   },
                   h('p', null, 'Select a repository and branch from the left panel')
                 )
+            )
+          );
+
+        const logoutButton =
+          typeof onLogout === 'function'
+            ? h(
+                'button',
+                {
+                  type: 'button',
+                  onClick: onLogout,
+                  disabled: Boolean(isLoggingOut),
+                  'aria-busy': isLoggingOut ? 'true' : undefined,
+                  className:
+                    'absolute top-4 right-4 z-30 inline-flex items-center gap-2 rounded-md border border-neutral-700 bg-neutral-900/90 px-3 py-2 text-xs font-medium text-neutral-200 shadow-sm transition-colors hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-70'
+                },
+                isLoggingOut
+                  ? h(
+                      Fragment,
+                      null,
+                      renderSpinner('text-neutral-200'),
+                      h('span', null, 'Logging out…')
+                    )
+                  : h('span', null, 'Log out')
               )
-        );
+            : null;
 
         return h(
           Fragment,
@@ -1035,6 +1229,7 @@
           h(
             'div',
             { className: 'flex h-screen bg-neutral-950 text-neutral-100 relative flex-col lg:flex-row min-h-0' },
+            logoutButton,
             desktopSidebar,
             mobileSidebar,
             h(
@@ -1321,7 +1516,74 @@
       }
 
       function App() {
-        return h(Fragment, null, h(RepoBrowser));
+        const [authStatus, setAuthStatus] = useState('checking');
+        const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+        const checkAuthStatus = useCallback(async () => {
+          try {
+            const response = await fetch('/api/auth/status', { credentials: 'include' });
+            if (!response.ok) {
+              setAuthStatus('unauthenticated');
+              return;
+            }
+            const body = await response.json();
+            setAuthStatus(body && body.authenticated ? 'authenticated' : 'unauthenticated');
+          } catch (error) {
+            setAuthStatus('unauthenticated');
+          }
+        }, []);
+
+        useEffect(() => {
+          checkAuthStatus();
+        }, [checkAuthStatus]);
+
+        const handleAuthenticated = useCallback(() => {
+          setAuthStatus('authenticated');
+          checkAuthStatus();
+        }, [checkAuthStatus]);
+
+        const handleAuthExpired = useCallback(() => {
+          setIsLoggingOut(false);
+          setAuthStatus('unauthenticated');
+        }, []);
+
+        const handleLogout = useCallback(async () => {
+          if (isLoggingOut) {
+            return;
+          }
+          setIsLoggingOut(true);
+          try {
+            await fetch('/api/auth/logout', {
+              method: 'POST',
+              credentials: 'include'
+            });
+          } catch {
+          } finally {
+            setIsLoggingOut(false);
+            setAuthStatus('unauthenticated');
+          }
+        }, [isLoggingOut]);
+
+        if (authStatus === 'checking') {
+          return h(
+            'div',
+            {
+              className:
+                'min-h-screen flex items-center justify-center bg-neutral-950 text-neutral-400 font-mono text-sm'
+            },
+            'Checking authentication…'
+          );
+        }
+
+        if (authStatus !== 'authenticated') {
+          return h(LoginScreen, { onAuthenticated: handleAuthenticated });
+        }
+
+        return h(RepoBrowser, {
+          onAuthExpired: handleAuthExpired,
+          onLogout: handleLogout,
+          isLoggingOut
+        });
       }
 
       const root = createRoot(document.getElementById('root'));


### PR DESCRIPTION
## Summary
- add secure password + session middleware to server routes and websocket
- expose `--password` CLI flag and log chosen credential on startup
- gate the React UI behind a login screen with logout and auth-aware fetches

## Testing
- not run (UI/backend change set)
