### PR TITLE
Add VS Code worktree option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ guarded against duplicate signals and cleans up HTTP, WebSocket, tmux, and PTY r
 - TailwindCSS + PostCSS deliver the utility classes formerly provided by `cdn.tailwindcss.com`.
 - `re-resizable` powers the sidebar resize on desktop; mobile view swaps to a hamburger drawer.
 - Modals cover Add Repo, Create Worktree, Delete Worktree, and “How do you want to open this
-  worktree?” action chooser (Terminal/Codex/Cursor/Claude auto-fill terminal input on first launch).
+  worktree?” action chooser (Terminal/VS Code/Codex/Cursor/Claude auto-fill terminal input on first launch).
 - xterm.js + fit addon render the terminal, preserve scrollback, and keep geometry synced via
   `ResizeObserver`.
 

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -911,7 +911,8 @@ function LoginScreen({ onAuthenticated }) {
             terminal: undefined,
             codex: 'codex',
             cursor: 'cursor-agent',
-            claude: 'claude'
+            claude: 'claude',
+            vscode: 'code .'
           };
           const command = commandMap[action];
           setActiveWorktree(worktree);
@@ -1530,6 +1531,24 @@ function LoginScreen({ onAuthenticated }) {
                             'Opening…'
                           )
                         : 'Open Terminal'
+                    ),
+                    h(
+                      'button',
+                      {
+                        onClick: () => handleWorktreeAction('vscode'),
+                        disabled: Boolean(pendingActionLoading),
+                        'aria-busy': pendingActionLoading === 'vscode',
+                        className:
+                          'w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 hover:border-neutral-500 hover:bg-neutral-850 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-neutral-700 disabled:hover:bg-neutral-900'
+                      },
+                      pendingActionLoading === 'vscode'
+                        ? h(
+                            'span',
+                            { className: 'inline-flex items-center gap-2' },
+                            renderSpinner('text-neutral-100'),
+                            'Opening…'
+                          )
+                        : 'Open in VS Code'
                     ),
                     h(
                       'button',


### PR DESCRIPTION
## Summary
- add VS Code action button to the worktree launch modal
- enqueue `code .` when VS Code is selected so the editor opens alongside the terminal
- document the new option in the agent handbook

## Testing
- not run (not requested)
