### PR TITLE
Add configurable agent launch commands

### DIFF
--- a/src/api/config.js
+++ b/src/api/config.js
@@ -1,0 +1,18 @@
+import { sendJson } from '../utils/http.js';
+
+export function createConfigHandlers(agentCommands) {
+  const resolved = {
+    codex: agentCommands?.codex || '',
+    codexDangerous: agentCommands?.codexDangerous || '',
+    claude: agentCommands?.claude || '',
+    claudeDangerous: agentCommands?.claudeDangerous || '',
+    ide: agentCommands?.ide || '',
+    vscode: agentCommands?.vscode || '',
+  };
+
+  async function commands(context) {
+    sendJson(context.res, 200, { commands: resolved });
+  }
+
+  return { commands };
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,6 +20,10 @@ Options:
   -u, --ui <path>        Path to the UI directory or entry file (default: bundled build)
   -w, --workdir <path>   Working directory root (default: current directory)
   -P, --password <string>  Password for login (default: randomly generated)
+      --codex-command <cmd>   Command executed when launching Codex (default: codex)
+      --claude-command <cmd>  Command executed when launching Claude (default: claude)
+      --ide-command <cmd>     Command executed when launching the IDE option (default: cursor-agent)
+      --vscode-command <cmd>  Command executed when launching VS Code (default: code .)
   -h, --help             Display this help message
   -v, --version          Output the version number
 `;
@@ -33,6 +37,10 @@ function parseArgs(argv) {
     ui: null,
     workdir: null,
     password: null,
+    codexCommand: null,
+    claudeCommand: null,
+    ideCommand: null,
+    vscodeCommand: null,
     help: false,
     version: false,
   };
@@ -94,6 +102,38 @@ function parseArgs(argv) {
         args.password = trimmed;
         break;
       }
+      case '--codex-command': {
+        const value = argv[++i];
+        if (!value) {
+          throw new Error(`Expected command value after ${token}`);
+        }
+        args.codexCommand = value;
+        break;
+      }
+      case '--claude-command': {
+        const value = argv[++i];
+        if (!value) {
+          throw new Error(`Expected command value after ${token}`);
+        }
+        args.claudeCommand = value;
+        break;
+      }
+      case '--ide-command': {
+        const value = argv[++i];
+        if (!value) {
+          throw new Error(`Expected command value after ${token}`);
+        }
+        args.ideCommand = value;
+        break;
+      }
+      case '--vscode-command': {
+        const value = argv[++i];
+        if (!value) {
+          throw new Error(`Expected command value after ${token}`);
+        }
+        args.vscodeCommand = value;
+        break;
+      }
       case '--help':
       case '-h':
         args.help = true;
@@ -143,14 +183,28 @@ async function main(argv = process.argv.slice(2)) {
   const resolvedUiPath = args.ui
     ? path.resolve(process.cwd(), args.ui)
     : BUNDLED_UI_PATH;
+  const commandOverrides = {
+    codex: args.codexCommand,
+    claude: args.claudeCommand,
+    ide: args.ideCommand,
+    vscode: args.vscodeCommand,
+  };
 
   try {
-    const { server, host, port, uiPath: resolvedUi, close, password: serverPassword } = await startServer({
+    const {
+      server,
+      host,
+      port,
+      uiPath: resolvedUi,
+      close,
+      password: serverPassword,
+    } = await startServer({
       uiPath: resolvedUiPath,
       port: args.port,
       host: args.host,
       workdir: workingDir,
       password: chosenPassword,
+      commandOverrides,
     });
 
     const localAddress = host === '0.0.0.0' ? 'localhost' : host;

--- a/src/config/agent-commands.js
+++ b/src/config/agent-commands.js
@@ -1,0 +1,61 @@
+const DEFAULT_CODEX_COMMAND = 'codex';
+const DEFAULT_CODEX_DANGEROUS_SUFFIX = '--dangerously-bypass-approvals-and-sandbox';
+const DEFAULT_CLAUDE_COMMAND = 'claude';
+const DEFAULT_CLAUDE_DANGEROUS_SUFFIX = '--dangerously-skip-permissions';
+const DEFAULT_IDE_COMMAND = 'cursor-agent';
+const DEFAULT_VSCODE_COMMAND = 'code .';
+
+export const DEFAULT_AGENT_COMMANDS = {
+  codex: `${DEFAULT_CODEX_COMMAND}`,
+  codexDangerous: `${DEFAULT_CODEX_COMMAND} ${DEFAULT_CODEX_DANGEROUS_SUFFIX}`,
+  claude: `${DEFAULT_CLAUDE_COMMAND}`,
+  claudeDangerous: `${DEFAULT_CLAUDE_COMMAND} ${DEFAULT_CLAUDE_DANGEROUS_SUFFIX}`,
+  ide: `${DEFAULT_IDE_COMMAND}`,
+  vscode: `${DEFAULT_VSCODE_COMMAND}`,
+};
+
+function appendDangerSuffix(base, suffix) {
+  const trimmed = typeof base === 'string' ? base.trim() : '';
+  if (!trimmed) {
+    return '';
+  }
+  return `${trimmed} ${suffix}`.trim();
+}
+
+export function createAgentCommands(overrides = {}) {
+  const codexBase =
+    typeof overrides.codex === 'string' && overrides.codex.trim()
+      ? overrides.codex.trim()
+      : DEFAULT_AGENT_COMMANDS.codex;
+  const claudeBase =
+    typeof overrides.claude === 'string' && overrides.claude.trim()
+      ? overrides.claude.trim()
+      : DEFAULT_AGENT_COMMANDS.claude;
+  const ideCommand =
+    typeof overrides.ide === 'string' && overrides.ide.trim()
+      ? overrides.ide.trim()
+      : DEFAULT_AGENT_COMMANDS.ide;
+  const vscodeCommand =
+    typeof overrides.vscode === 'string' && overrides.vscode.trim()
+      ? overrides.vscode.trim()
+      : DEFAULT_AGENT_COMMANDS.vscode;
+
+  const codexDangerous =
+    typeof overrides.codexDangerous === 'string' && overrides.codexDangerous.trim()
+      ? overrides.codexDangerous.trim()
+      : appendDangerSuffix(codexBase, DEFAULT_CODEX_DANGEROUS_SUFFIX);
+
+  const claudeDangerous =
+    typeof overrides.claudeDangerous === 'string' && overrides.claudeDangerous.trim()
+      ? overrides.claudeDangerous.trim()
+      : appendDangerSuffix(claudeBase, DEFAULT_CLAUDE_DANGEROUS_SUFFIX);
+
+  return {
+    codex: codexBase,
+    codexDangerous,
+    claude: claudeBase,
+    claudeDangerous,
+    ide: ideCommand,
+    vscode: vscodeCommand,
+  };
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -9,6 +9,7 @@ import { sendJson } from '../utils/http.js';
 import { createRouter } from './router.js';
 import { attachTerminalWebSockets } from './websocket.js';
 import { createUiProvider } from './ui.js';
+import { createAgentCommands } from '../config/agent-commands.js';
 
 export async function startServer({
   uiPath,
@@ -16,6 +17,7 @@ export async function startServer({
   host = DEFAULT_HOST,
   workdir,
   password,
+  commandOverrides,
 } = {}) {
   if (!uiPath) {
     throw new Error('Missing required option: uiPath');
@@ -26,7 +28,8 @@ export async function startServer({
   const resolvedPassword =
     typeof password === 'string' && password.length > 0 ? password : generateRandomPassword();
   const authManager = createAuthManager(resolvedPassword);
-  const router = createRouter({ authManager, workdir: resolvedWorkdir });
+  const agentCommands = createAgentCommands(commandOverrides);
+  const router = createRouter({ authManager, workdir: resolvedWorkdir, agentCommands });
 
   const server = http.createServer(async (req, res) => {
     try {
@@ -91,6 +94,7 @@ export async function startServer({
     workdir: resolvedWorkdir,
     close: closeAll,
     password: resolvedPassword,
+    commands: agentCommands,
   };
 }
 

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -4,10 +4,14 @@ import { createSessionHandlers } from '../api/sessions.js';
 import { createTerminalHandlers } from '../api/terminal.js';
 import { createWorktreeHandlers } from '../api/worktrees.js';
 import { sendJson, readJsonBody } from '../utils/http.js';
+import { createConfigHandlers } from '../api/config.js';
 
-export function createRouter({ authManager, workdir }) {
+export function createRouter({ authManager, workdir, agentCommands }) {
   if (!authManager) {
     throw new Error('authManager is required');
+  }
+  if (!agentCommands) {
+    throw new Error('agentCommands is required');
   }
 
   const authHandlers = createAuthHandlers(authManager);
@@ -15,6 +19,7 @@ export function createRouter({ authManager, workdir }) {
   const sessionHandlers = createSessionHandlers(workdir);
   const worktreeHandlers = createWorktreeHandlers(workdir);
   const terminalHandlers = createTerminalHandlers(workdir);
+  const configHandlers = createConfigHandlers(agentCommands);
 
   const routes = new Map([
     [
@@ -76,6 +81,13 @@ export function createRouter({ authManager, workdir }) {
       {
         requiresAuth: true,
         handlers: { POST: terminalHandlers.send },
+      },
+    ],
+    [
+      '/api/commands',
+      {
+        requiresAuth: true,
+        handlers: { GET: configHandlers.commands, HEAD: configHandlers.commands },
       },
     ],
   ]);


### PR DESCRIPTION
## Summary
- add CLI flags to override agent commands and propagate to server startup
- expose resolved agent commands via /api/commands and frontend fetch
- update worktree action modal to use configurable commands and rename IDE option

## Testing
- npm run build