### PR TITLE
Update Cursor launch configuration

### DIFF
--- a/src/api/config.js
+++ b/src/api/config.js
@@ -6,7 +6,7 @@ export function createConfigHandlers(agentCommands) {
     codexDangerous: agentCommands?.codexDangerous || '',
     claude: agentCommands?.claude || '',
     claudeDangerous: agentCommands?.claudeDangerous || '',
-    ide: agentCommands?.ide || '',
+    cursor: agentCommands?.cursor || '',
     vscode: agentCommands?.vscode || '',
   };
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,7 +22,8 @@ Options:
   -P, --password <string>  Password for login (default: randomly generated)
       --codex-command <cmd>   Command executed when launching Codex (default: codex)
       --claude-command <cmd>  Command executed when launching Claude (default: claude)
-      --ide-command <cmd>     Command executed when launching the IDE option (default: cursor-agent)
+      --cursor-command <cmd>  Command executed when launching Cursor (default: cursor-agent)
+      --ide-command <cmd>     (deprecated) Alias for --cursor-command
       --vscode-command <cmd>  Command executed when launching VS Code (default: code .)
   -h, --help             Display this help message
   -v, --version          Output the version number
@@ -39,6 +40,7 @@ function parseArgs(argv) {
     password: null,
     codexCommand: null,
     claudeCommand: null,
+    cursorCommand: null,
     ideCommand: null,
     vscodeCommand: null,
     help: false,
@@ -118,6 +120,14 @@ function parseArgs(argv) {
         args.claudeCommand = value;
         break;
       }
+      case '--cursor-command': {
+        const value = argv[++i];
+        if (!value) {
+          throw new Error(`Expected command value after ${token}`);
+        }
+        args.cursorCommand = value;
+        break;
+      }
       case '--ide-command': {
         const value = argv[++i];
         if (!value) {
@@ -186,6 +196,7 @@ async function main(argv = process.argv.slice(2)) {
   const commandOverrides = {
     codex: args.codexCommand,
     claude: args.claudeCommand,
+    cursor: args.cursorCommand ?? args.ideCommand,
     ide: args.ideCommand,
     vscode: args.vscodeCommand,
   };

--- a/src/config/agent-commands.js
+++ b/src/config/agent-commands.js
@@ -2,7 +2,7 @@ const DEFAULT_CODEX_COMMAND = 'codex';
 const DEFAULT_CODEX_DANGEROUS_SUFFIX = '--dangerously-bypass-approvals-and-sandbox';
 const DEFAULT_CLAUDE_COMMAND = 'claude';
 const DEFAULT_CLAUDE_DANGEROUS_SUFFIX = '--dangerously-skip-permissions';
-const DEFAULT_IDE_COMMAND = 'cursor-agent';
+const DEFAULT_CURSOR_COMMAND = 'cursor-agent';
 const DEFAULT_VSCODE_COMMAND = 'code .';
 
 export const DEFAULT_AGENT_COMMANDS = {
@@ -10,7 +10,7 @@ export const DEFAULT_AGENT_COMMANDS = {
   codexDangerous: `${DEFAULT_CODEX_COMMAND} ${DEFAULT_CODEX_DANGEROUS_SUFFIX}`,
   claude: `${DEFAULT_CLAUDE_COMMAND}`,
   claudeDangerous: `${DEFAULT_CLAUDE_COMMAND} ${DEFAULT_CLAUDE_DANGEROUS_SUFFIX}`,
-  ide: `${DEFAULT_IDE_COMMAND}`,
+  cursor: `${DEFAULT_CURSOR_COMMAND}`,
   vscode: `${DEFAULT_VSCODE_COMMAND}`,
 };
 
@@ -31,10 +31,15 @@ export function createAgentCommands(overrides = {}) {
     typeof overrides.claude === 'string' && overrides.claude.trim()
       ? overrides.claude.trim()
       : DEFAULT_AGENT_COMMANDS.claude;
-  const ideCommand =
-    typeof overrides.ide === 'string' && overrides.ide.trim()
-      ? overrides.ide.trim()
-      : DEFAULT_AGENT_COMMANDS.ide;
+  const cursorCommand = (() => {
+    if (typeof overrides.cursor === 'string' && overrides.cursor.trim()) {
+      return overrides.cursor.trim();
+    }
+    if (typeof overrides.ide === 'string' && overrides.ide.trim()) {
+      return overrides.ide.trim();
+    }
+    return DEFAULT_AGENT_COMMANDS.cursor;
+  })();
   const vscodeCommand =
     typeof overrides.vscode === 'string' && overrides.vscode.trim()
       ? overrides.vscode.trim()
@@ -55,7 +60,7 @@ export function createAgentCommands(overrides = {}) {
     codexDangerous,
     claude: claudeBase,
     claudeDangerous,
-    ide: ideCommand,
+    cursor: cursorCommand,
     vscode: vscodeCommand,
   };
 }

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -13,7 +13,7 @@ const DEFAULT_COMMAND_CONFIG = Object.freeze({
   codexDangerous: 'codex --dangerously-bypass-approvals-and-sandbox',
   claude: 'claude',
   claudeDangerous: 'claude --dangerously-skip-permissions',
-  ide: 'cursor-agent',
+  cursor: 'cursor-agent',
   vscode: 'code .'
 });
 
@@ -295,7 +295,10 @@ function LoginScreen({ onAuthenticated }) {
                   commands.claudeDangerous,
                   DEFAULT_COMMAND_CONFIG.claudeDangerous
                 ),
-                ide: parseCommand(commands.ide, DEFAULT_COMMAND_CONFIG.ide),
+                cursor: parseCommand(
+                  commands.cursor ?? commands.ide,
+                  DEFAULT_COMMAND_CONFIG.cursor
+                ),
                 vscode: parseCommand(commands.vscode, DEFAULT_COMMAND_CONFIG.vscode),
               };
               if (!cancelled) {
@@ -1025,7 +1028,8 @@ function LoginScreen({ onAuthenticated }) {
             terminal: undefined,
             codex: commandConfig.codex,
             'codex-dangerous': commandConfig.codexDangerous,
-            ide: commandConfig.ide,
+            cursor: commandConfig.cursor,
+            ide: commandConfig.cursor,
             claude: commandConfig.claude,
             'claude-dangerous': commandConfig.claudeDangerous,
             vscode: commandConfig.vscode,
@@ -1056,7 +1060,8 @@ function LoginScreen({ onAuthenticated }) {
           Boolean(pendingActionLoading && typeof pendingActionLoading === 'string' && pendingActionLoading.startsWith('codex'));
         const isClaudeLoading =
           Boolean(pendingActionLoading && typeof pendingActionLoading === 'string' && pendingActionLoading.startsWith('claude'));
-        const isIdeLoading = pendingActionLoading === 'ide';
+        const isCursorLoading =
+          pendingActionLoading === 'cursor' || pendingActionLoading === 'ide';
 
         const statusStyles = {
           connected: 'border border-emerald-500/40 text-emerald-300 bg-emerald-500/15',
@@ -1458,6 +1463,14 @@ function LoginScreen({ onAuthenticated }) {
                   h('input', {
                     value: branchName,
                     onChange: event => setBranchName(event.target.value),
+                    onKeyDown: event => {
+                      if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
+                        event.preventDefault();
+                        if (!isCreatingWorktree) {
+                          handleCreateWorktree();
+                        }
+                      }
+                    },
                     placeholder: 'feature/my-awesome-branch',
                     className:
                       'w-full rounded-md border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-500/60'
@@ -1757,20 +1770,20 @@ function LoginScreen({ onAuthenticated }) {
                     h(
                       'button',
                       {
-                        onClick: () => handleWorktreeAction('ide'),
+                        onClick: () => handleWorktreeAction('cursor'),
                         disabled: Boolean(pendingActionLoading),
-                        'aria-busy': isIdeLoading,
+                        'aria-busy': isCursorLoading,
                         className:
                           'w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 hover:border-neutral-500 hover:bg-neutral-850 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-neutral-700 disabled:hover:bg-neutral-900'
                       },
-                      isIdeLoading
+                      isCursorLoading
                         ? h(
                             'span',
                             { className: 'inline-flex items-center gap-2' },
                             renderSpinner('text-neutral-100'),
                             'Launching…'
                           )
-                        : 'Launch IDE'
+                        : 'Launch Cursor'
                     ),
                     h(
                       'div',


### PR DESCRIPTION
## Summary
- rename IDE launcher option to Cursor in the UI
- expose a --cursor-command flag in the CLI while keeping --ide-command as a fallback
- normalise cursor command propagation through the API so the modal launches the right command]