### PR TITLE
Add ngrok tunneling and config save functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,47 @@ node bin/terminal-worktree.js \
 - `-u, --ui <path>` – Directory or entry file for the built UI (default: `ui/dist`)
 - `-w, --workdir <path>` – Root directory that holds `org/repo` folders (default: process CWD)
 - `-P, --password <string>` – UI password (default: secure random string printed at startup)
+- `--ngrok-api-key <token>` – Authtoken used to establish a public ngrok tunnel
+- `--ngrok-domain <domain>` – Reserved ngrok domain exposed when tunnelling (requires `--ngrok-api-key`)
+- `--save` – Persist the effective configuration to `~/.terminal-worktree/config.json` and exit
 - `-h, --help` – Print usage
 - `-v, --version` – Show package version
+
+When both ngrok flags are supplied the CLI will establish a tunnel after the HTTP server boots and
+print the public URL. If either flag is omitted the service remains reachable only via the bound host
+and port.
+
+### Configuration File
+
+At startup the CLI also reads `~/.terminal-worktree/config.json` if it exists. Any values in that file
+fill in defaults for matching CLI options, while explicit command-line arguments always win. A simple
+configuration might look like:
+
+```json
+{
+  "port": 4001,
+  "host": "127.0.0.1",
+  "ui": "./ui/dist",
+  "workdir": "/srv/worktrees",
+  "password": "s3cr3t",
+  "commands": {
+    "codex": "codex",
+    "cursor": "cursor-agent",
+    "vscode": "code ."
+  },
+  "ngrok": {
+    "apiKey": "NGROK_AUTHTOKEN",
+    "domain": "example.ngrok.app"
+  }
+}
+```
+
+Supported keys mirror the CLI flags (`port`, `host`, `ui`, `workdir`, `password`, individual
+`*Command` entries, plus `ngrokApiKey`/`ngrokDomain` or `ngrok.apiKey` / `ngrok.domain`). Leave the
+file absent to continue using only CLI arguments.
+
+Run `terminal-worktree --port 4001 --workdir /srv/worktrees --save` to save the provided values into
+the config file without starting the server.
 
 ### Authentication
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "terminal-worktree",
       "dependencies": {
+        "@ngrok/ngrok": "^1.5.2",
         "@tailwindcss/postcss": "^4.1.16",
         "@vitejs/plugin-react": "^5.1.0",
         "autoprefixer": "^10.4.21",
@@ -138,6 +139,34 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@ngrok/ngrok": ["@ngrok/ngrok@1.5.2", "", { "optionalDependencies": { "@ngrok/ngrok-android-arm64": "1.5.2", "@ngrok/ngrok-darwin-arm64": "1.5.2", "@ngrok/ngrok-darwin-universal": "1.5.2", "@ngrok/ngrok-darwin-x64": "1.5.2", "@ngrok/ngrok-freebsd-x64": "1.5.2", "@ngrok/ngrok-linux-arm-gnueabihf": "1.5.2", "@ngrok/ngrok-linux-arm64-gnu": "1.5.2", "@ngrok/ngrok-linux-arm64-musl": "1.5.2", "@ngrok/ngrok-linux-x64-gnu": "1.5.2", "@ngrok/ngrok-linux-x64-musl": "1.5.2", "@ngrok/ngrok-win32-arm64-msvc": "1.5.2", "@ngrok/ngrok-win32-ia32-msvc": "1.5.2", "@ngrok/ngrok-win32-x64-msvc": "1.5.2" } }, "sha512-gN7KKdLTKer+wBSk9s9eDx53MUFdcnXNHsXxiC5sJLLD5HY9JRMSn6UzcCqnk7IgeIgCgw5h1k6YDqhjx6lmtg=="],
+
+    "@ngrok/ngrok-android-arm64": ["@ngrok/ngrok-android-arm64@1.5.2", "", { "os": "android", "cpu": "arm64" }, "sha512-v81VbxxAgg2W7jbjhEcn8K9R2aUf0h1AuTx+8tDlw3L4H1YEmbmllIpBAGgMjHRBxLZKOo5GBi0k7oS+VRM5TA=="],
+
+    "@ngrok/ngrok-darwin-arm64": ["@ngrok/ngrok-darwin-arm64@1.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8CVzS9AveYpNhWbydm7cJ6XqmVg29/VRKF15l4kJ2djlNoJxuGSibgM9A627dWRdnJyj5uhmU3VzsgeU8t+/3g=="],
+
+    "@ngrok/ngrok-darwin-universal": ["@ngrok/ngrok-darwin-universal@1.5.2", "", { "os": "darwin" }, "sha512-mEMH1OxN6RxnqRSWb4xY9RqbtdlCpv+WlRKxq4lVy8JVsxEyFNnzVQ0jn+iuiy981jCXjokctzJeGMvECuSQBQ=="],
+
+    "@ngrok/ngrok-darwin-x64": ["@ngrok/ngrok-darwin-x64@1.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-rGdcADw4NtMSU7SHUTly7uvMVYX6eMeMCppKyL5g3CSlEQntKf3AWs/89ah2TBWJA2WVl0UgGLkXp4xs1tg9eQ=="],
+
+    "@ngrok/ngrok-freebsd-x64": ["@ngrok/ngrok-freebsd-x64@1.5.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-WgY54qUekaUGa5+lFvzYUMjlzf22IEXuZHhxnzJM2/gMqa7gjU8N5W4U8XNDjVW/oz6DekrzIjuoAEPO+2icDg=="],
+
+    "@ngrok/ngrok-linux-arm-gnueabihf": ["@ngrok/ngrok-linux-arm-gnueabihf@1.5.2", "", { "os": "linux", "cpu": "arm" }, "sha512-azMxr/TGEeFU4JAUbSu5MO2aZEvdq+TzcxiLw6d+yhdEtNAjDW9TOyCczTrIZPOG5fP8G3lcCd8TP7mVIWdOnw=="],
+
+    "@ngrok/ngrok-linux-arm64-gnu": ["@ngrok/ngrok-linux-arm64-gnu@1.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-79eFCxio4rM0ICRBXx/CVvbXDeWk1Jxr7szkezEYWtHaL+gXivrtS1QjtMnJpGY1GJlLTQL+49w2lGydqPOJQA=="],
+
+    "@ngrok/ngrok-linux-arm64-musl": ["@ngrok/ngrok-linux-arm64-musl@1.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-ou9Z7iPQJIQ0RX5bdBhb3y7GwYRt+X0G9tenyRzKLXXvs0XfUUcg/23aBP61hmdRvBq7xpliV1PnvEVBgUIYMg=="],
+
+    "@ngrok/ngrok-linux-x64-gnu": ["@ngrok/ngrok-linux-x64-gnu@1.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-VI1mmtl3Ie5uXTVAR9thPiMNMsCWeqkjBUbHAyk2vZ2OXR4Vs2DGjOPXK+wTl/hjF29FXoxunjhMy6caF9ht0Q=="],
+
+    "@ngrok/ngrok-linux-x64-musl": ["@ngrok/ngrok-linux-x64-musl@1.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-F4j9EyC/0R3IgYSd+OER4bC8bxuBubvj33e24GvQnRF/IQaKhpybkvQbz54fnvsL7y0j2BB42NAIm2CFtk7tCw=="],
+
+    "@ngrok/ngrok-win32-arm64-msvc": ["@ngrok/ngrok-win32-arm64-msvc@1.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-0OMXNjWElM1MQX7lMBnpRtafS9+3ybauqGD4m2dZcIm6hFvexsJFwNgx0mCa5aKxe2mQ4zNarEUd+SqG2Aa4/g=="],
+
+    "@ngrok/ngrok-win32-ia32-msvc": ["@ngrok/ngrok-win32-ia32-msvc@1.5.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-hdvhnr7Br4XhUblpW67v5XP6FyoQwJ2xSbwas4KW4hZ3F4cw0m6sqXpssRfmqg3/5HJony1H5B2jLi0x4J7uOw=="],
+
+    "@ngrok/ngrok-win32-x64-msvc": ["@ngrok/ngrok-win32-x64-msvc@1.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-aHuMiRti9Taow9DlYLGVmu9CXtXD/v4CBQWpZlmt7VGuK1KsTWWLaGIBFVp6UXnyW87b0A+KC69Kn/Xjylw+sg=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.43", "", {}, "sha512-5Uxg7fQUCmfhax7FJke2+8B6cqgeUJUD9o2uXIKXhD+mG0mL6NObmVoi9wXEU1tY89mZKgAYA6fTbftx3q2ZPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@ngrok/ngrok": "^1.5.2",
     "@tailwindcss/postcss": "^4.1.16",
     "@vitejs/plugin-react": "^5.1.0",
     "autoprefixer": "^10.4.21",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -10,6 +12,255 @@ import {
 } from './server/index.js';
 
 const BUNDLED_UI_PATH = fileURLToPath(new URL('../ui/dist', import.meta.url));
+const CONFIG_DIR_NAME = '.terminal-worktree';
+const CONFIG_FILE_NAME = 'config.json';
+
+function warnConfig(message) {
+  process.stderr.write(`[terminal-worktree] ${message}\n`);
+}
+
+function getConfigFilePath() {
+  const homeDir = os.homedir();
+  if (!homeDir) {
+    return null;
+  }
+  return path.join(homeDir, CONFIG_DIR_NAME, CONFIG_FILE_NAME);
+}
+
+function coercePort(value, name, configPath) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  let portValue = value;
+  if (typeof portValue === 'string') {
+    const trimmed = portValue.trim();
+    if (!trimmed) {
+      warnConfig(`Ignoring empty ${name} in ${configPath || 'config'}`);
+      return undefined;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    portValue = parsed;
+  }
+
+  if (!Number.isInteger(portValue) || portValue < 1 || portValue > 65535) {
+    warnConfig(`Ignoring invalid ${name} in ${configPath || 'config'}; expected port between 1-65535.`);
+    return undefined;
+  }
+
+  return portValue;
+}
+
+function coerceString(value, name, configPath) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    warnConfig(`Ignoring non-string ${name} in ${configPath || 'config'}.`);
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    warnConfig(`Ignoring empty ${name} in ${configPath || 'config'}.`);
+    return undefined;
+  }
+
+  return trimmed;
+}
+
+function pickString(sources, configPath) {
+  for (const { value, name } of sources) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    const coerced = coerceString(value, name, configPath);
+    if (coerced !== undefined) {
+      return coerced;
+    }
+  }
+  return undefined;
+}
+
+function normalizeConfig(rawConfig, configPath) {
+  if (!rawConfig || typeof rawConfig !== 'object') {
+    if (rawConfig !== undefined) {
+      warnConfig(`Ignoring config at ${configPath || 'config'} because it is not a JSON object.`);
+    }
+    return {};
+  }
+
+  const normalized = {};
+  const commands =
+    rawConfig.commands && typeof rawConfig.commands === 'object'
+      ? rawConfig.commands
+      : null;
+  const ngrok =
+    rawConfig.ngrok && typeof rawConfig.ngrok === 'object'
+      ? rawConfig.ngrok
+      : null;
+
+  const port = coercePort(rawConfig.port, 'port', configPath);
+  if (port !== undefined) {
+    normalized.port = port;
+  }
+
+  const host = coerceString(rawConfig.host, 'host', configPath);
+  if (host !== undefined) {
+    normalized.host = host;
+  }
+
+  const ui = pickString(
+    [
+      { value: rawConfig.ui, name: 'ui' },
+      { value: rawConfig.uiPath, name: 'uiPath' },
+    ],
+    configPath,
+  );
+  if (ui !== undefined) {
+    normalized.ui = ui;
+  }
+
+  const workdir = pickString(
+    [
+      { value: rawConfig.workdir, name: 'workdir' },
+      { value: rawConfig.workDir, name: 'workDir' },
+    ],
+    configPath,
+  );
+  if (workdir !== undefined) {
+    normalized.workdir = workdir;
+  }
+
+  const password = coerceString(rawConfig.password, 'password', configPath);
+  if (password !== undefined) {
+    normalized.password = password;
+  }
+
+  const codexCommand = pickString(
+    [
+      { value: rawConfig.codexCommand, name: 'codexCommand' },
+      { value: commands?.codex, name: 'commands.codex' },
+    ],
+    configPath,
+  );
+  if (codexCommand !== undefined) {
+    normalized.codexCommand = codexCommand;
+  }
+
+  const claudeCommand = pickString(
+    [
+      { value: rawConfig.claudeCommand, name: 'claudeCommand' },
+      { value: commands?.claude, name: 'commands.claude' },
+    ],
+    configPath,
+  );
+  if (claudeCommand !== undefined) {
+    normalized.claudeCommand = claudeCommand;
+  }
+
+  const cursorCommand = pickString(
+    [
+      { value: rawConfig.cursorCommand, name: 'cursorCommand' },
+      { value: commands?.cursor, name: 'commands.cursor' },
+    ],
+    configPath,
+  );
+  if (cursorCommand !== undefined) {
+    normalized.cursorCommand = cursorCommand;
+  }
+
+  const ideCommand = pickString(
+    [
+      { value: rawConfig.ideCommand, name: 'ideCommand' },
+      { value: commands?.ide, name: 'commands.ide' },
+    ],
+    configPath,
+  );
+  if (ideCommand !== undefined) {
+    normalized.ideCommand = ideCommand;
+  }
+
+  const vscodeCommand = pickString(
+    [
+      { value: rawConfig.vscodeCommand, name: 'vscodeCommand' },
+      { value: commands?.vscode, name: 'commands.vscode' },
+    ],
+    configPath,
+  );
+  if (vscodeCommand !== undefined) {
+    normalized.vscodeCommand = vscodeCommand;
+  }
+
+  const ngrokApiKey = pickString(
+    [
+      { value: rawConfig.ngrokApiKey, name: 'ngrokApiKey' },
+      { value: ngrok?.apiKey, name: 'ngrok.apiKey' },
+      { value: ngrok?.authtoken, name: 'ngrok.authtoken' },
+      { value: ngrok?.token, name: 'ngrok.token' },
+    ],
+    configPath,
+  );
+  if (ngrokApiKey !== undefined) {
+    normalized.ngrokApiKey = ngrokApiKey;
+  }
+
+  const ngrokDomain = pickString(
+    [
+      { value: rawConfig.ngrokDomain, name: 'ngrokDomain' },
+      { value: ngrok?.domain, name: 'ngrok.domain' },
+    ],
+    configPath,
+  );
+  if (ngrokDomain !== undefined) {
+    normalized.ngrokDomain = ngrokDomain;
+  }
+
+  return normalized;
+}
+
+async function loadConfig() {
+  const configPath = getConfigFilePath();
+  if (!configPath) {
+    return { values: {}, path: null };
+  }
+
+  let raw;
+  try {
+    raw = await fs.readFile(configPath, 'utf8');
+  } catch (error) {
+    if (error && (error.code === 'ENOENT' || error.code === 'ENOTDIR')) {
+      return { values: {}, path: configPath };
+    }
+    warnConfig(`Failed to read config at ${configPath}: ${error.message}`);
+    return { values: {}, path: configPath };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    warnConfig(`Failed to parse config at ${configPath}: ${error.message}`);
+    return { values: {}, path: configPath };
+  }
+
+  return { values: normalizeConfig(parsed, configPath), path: configPath };
+}
+
+async function saveConfigFile(configValues) {
+  const configPath = getConfigFilePath();
+  if (!configPath) {
+    throw new Error('Unable to resolve config file path (home directory not found).');
+  }
+
+  const dir = path.dirname(configPath);
+  await fs.mkdir(dir, { recursive: true });
+
+  const serialized = `${JSON.stringify(configValues, null, 2)}\n`;
+  await fs.writeFile(configPath, serialized, 'utf8');
+  return configPath;
+}
 
 function printHelp() {
   const helpText = `Usage: terminal-worktree [options]
@@ -25,6 +276,9 @@ Options:
       --cursor-command <cmd>  Command executed when launching Cursor (default: cursor-agent)
       --ide-command <cmd>     (deprecated) Alias for --cursor-command
       --vscode-command <cmd>  Command executed when launching VS Code (default: code .)
+      --ngrok-api-key <token> Authtoken used when establishing an ngrok tunnel
+      --ngrok-domain <domain> Reserved ngrok domain to expose the server publicly
+      --save               Persist the effective configuration and exit
   -h, --help             Display this help message
   -v, --version          Output the version number
 `;
@@ -32,6 +286,22 @@ Options:
 }
 
 function parseArgs(argv) {
+  const provided = {
+    port: false,
+    host: false,
+    ui: false,
+    workdir: false,
+    password: false,
+    codexCommand: false,
+    claudeCommand: false,
+    cursorCommand: false,
+    ideCommand: false,
+    vscodeCommand: false,
+    ngrokApiKey: false,
+    ngrokDomain: false,
+    save: false,
+  };
+
   const args = {
     port: DEFAULT_PORT,
     host: DEFAULT_HOST,
@@ -43,9 +313,17 @@ function parseArgs(argv) {
     cursorCommand: null,
     ideCommand: null,
     vscodeCommand: null,
+    ngrokApiKey: null,
+    ngrokDomain: null,
+    save: false,
     help: false,
     version: false,
   };
+
+  Object.defineProperty(args, '_provided', {
+    value: provided,
+    enumerable: false,
+  });
 
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
@@ -62,6 +340,7 @@ function parseArgs(argv) {
           throw new Error(`Invalid port: ${value}`);
         }
         args.port = parsed;
+        provided.port = true;
         break;
       }
       case '--host':
@@ -71,6 +350,7 @@ function parseArgs(argv) {
           throw new Error(`Expected host value after ${token}`);
         }
         args.host = value;
+        provided.host = true;
         break;
       }
       case '--ui':
@@ -80,6 +360,7 @@ function parseArgs(argv) {
           throw new Error(`Expected path value after ${token}`);
         }
         args.ui = value;
+        provided.ui = true;
         break;
       }
       case '--workdir':
@@ -89,6 +370,7 @@ function parseArgs(argv) {
           throw new Error(`Expected path value after ${token}`);
         }
         args.workdir = value;
+        provided.workdir = true;
         break;
       }
       case '--password':
@@ -102,6 +384,7 @@ function parseArgs(argv) {
           throw new Error('Password cannot be empty');
         }
         args.password = trimmed;
+        provided.password = true;
         break;
       }
       case '--codex-command': {
@@ -110,6 +393,7 @@ function parseArgs(argv) {
           throw new Error(`Expected command value after ${token}`);
         }
         args.codexCommand = value;
+        provided.codexCommand = true;
         break;
       }
       case '--claude-command': {
@@ -118,6 +402,7 @@ function parseArgs(argv) {
           throw new Error(`Expected command value after ${token}`);
         }
         args.claudeCommand = value;
+        provided.claudeCommand = true;
         break;
       }
       case '--cursor-command': {
@@ -126,6 +411,7 @@ function parseArgs(argv) {
           throw new Error(`Expected command value after ${token}`);
         }
         args.cursorCommand = value;
+        provided.cursorCommand = true;
         break;
       }
       case '--ide-command': {
@@ -134,6 +420,7 @@ function parseArgs(argv) {
           throw new Error(`Expected command value after ${token}`);
         }
         args.ideCommand = value;
+        provided.ideCommand = true;
         break;
       }
       case '--vscode-command': {
@@ -142,6 +429,38 @@ function parseArgs(argv) {
           throw new Error(`Expected command value after ${token}`);
         }
         args.vscodeCommand = value;
+        provided.vscodeCommand = true;
+        break;
+      }
+      case '--ngrok-api-key': {
+        const value = argv[++i];
+        if (!value) {
+          throw new Error(`Expected ngrok API key after ${token}`);
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+          throw new Error('ngrok API key cannot be empty');
+        }
+        args.ngrokApiKey = trimmed;
+        provided.ngrokApiKey = true;
+        break;
+      }
+      case '--ngrok-domain': {
+        const value = argv[++i];
+        if (!value) {
+          throw new Error(`Expected domain value after ${token}`);
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+          throw new Error('ngrok domain cannot be empty');
+        }
+        args.ngrokDomain = trimmed;
+        provided.ngrokDomain = true;
+        break;
+      }
+      case '--save': {
+        args.save = true;
+        provided.save = true;
         break;
       }
       case '--help':
@@ -186,20 +505,121 @@ async function main(argv = process.argv.slice(2)) {
     return;
   }
 
-  const workingDir = args.workdir
-    ? path.resolve(process.cwd(), args.workdir)
+  const { values: fileConfig } = await loadConfig();
+  const provided = args._provided;
+
+  const finalPort = provided.port ? args.port : fileConfig.port ?? DEFAULT_PORT;
+  const finalHost = provided.host ? args.host : fileConfig.host ?? DEFAULT_HOST;
+  const finalUi = provided.ui ? args.ui : fileConfig.ui ?? null;
+  const finalWorkdir = provided.workdir ? args.workdir : fileConfig.workdir ?? null;
+  const finalPassword = provided.password ? args.password : fileConfig.password ?? null;
+
+  const finalCodexCommand = provided.codexCommand
+    ? args.codexCommand
+    : fileConfig.codexCommand ?? null;
+  const finalClaudeCommand = provided.claudeCommand
+    ? args.claudeCommand
+    : fileConfig.claudeCommand ?? null;
+  const finalIdeCommand = provided.ideCommand
+    ? args.ideCommand
+    : fileConfig.ideCommand ?? null;
+  const finalCursorCommand = provided.cursorCommand
+    ? args.cursorCommand
+    : provided.ideCommand
+      ? args.ideCommand
+      : fileConfig.cursorCommand ?? fileConfig.ideCommand ?? null;
+  const finalVscodeCommand = provided.vscodeCommand
+    ? args.vscodeCommand
+    : fileConfig.vscodeCommand ?? null;
+
+  const finalNgrokApiKey = provided.ngrokApiKey
+    ? args.ngrokApiKey
+    : fileConfig.ngrokApiKey ?? null;
+  const finalNgrokDomain = provided.ngrokDomain
+    ? args.ngrokDomain
+    : fileConfig.ngrokDomain ?? null;
+
+  if ((finalNgrokApiKey && !finalNgrokDomain) || (finalNgrokDomain && !finalNgrokApiKey)) {
+    process.stderr.write(
+      'Both --ngrok-api-key and --ngrok-domain must be provided together.\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const workdirInput = finalWorkdir ?? null;
+  const workingDir = workdirInput
+    ? path.resolve(process.cwd(), workdirInput)
     : process.cwd();
-  const chosenPassword = args.password || generateRandomPassword();
-  const resolvedUiPath = args.ui
-    ? path.resolve(process.cwd(), args.ui)
+  const uiInput = finalUi ?? null;
+  const resolvedUiPath = uiInput
+    ? path.resolve(process.cwd(), uiInput)
     : BUNDLED_UI_PATH;
+  const chosenPassword = finalPassword || generateRandomPassword();
   const commandOverrides = {
-    codex: args.codexCommand,
-    claude: args.claudeCommand,
-    cursor: args.cursorCommand ?? args.ideCommand,
-    ide: args.ideCommand,
-    vscode: args.vscodeCommand,
+    codex: finalCodexCommand,
+    claude: finalClaudeCommand,
+    cursor: finalCursorCommand ?? finalIdeCommand,
+    ide: finalIdeCommand,
+    vscode: finalVscodeCommand,
   };
+  const ngrokOptions =
+    finalNgrokApiKey && finalNgrokDomain
+      ? { apiKey: finalNgrokApiKey, domain: finalNgrokDomain }
+      : undefined;
+
+  if (args.save) {
+    const configToSave = {
+      port: finalPort,
+      host: finalHost,
+    };
+
+    if (uiInput) {
+      configToSave.ui = uiInput;
+    }
+    if (workdirInput) {
+      configToSave.workdir = workdirInput;
+    }
+    if (finalPassword) {
+      configToSave.password = finalPassword;
+    }
+
+    const commandsConfig = {};
+    if (finalCodexCommand) {
+      commandsConfig.codex = finalCodexCommand;
+    }
+    if (finalClaudeCommand) {
+      commandsConfig.claude = finalClaudeCommand;
+    }
+    if (finalCursorCommand) {
+      commandsConfig.cursor = finalCursorCommand;
+    }
+    if (finalIdeCommand) {
+      commandsConfig.ide = finalIdeCommand;
+    }
+    if (finalVscodeCommand) {
+      commandsConfig.vscode = finalVscodeCommand;
+    }
+    if (Object.keys(commandsConfig).length > 0) {
+      configToSave.commands = commandsConfig;
+    }
+
+    if (finalNgrokApiKey && finalNgrokDomain) {
+      configToSave.ngrok = {
+        apiKey: finalNgrokApiKey,
+        domain: finalNgrokDomain,
+      };
+    }
+
+    try {
+      const savedPath = await saveConfigFile(configToSave);
+      process.stdout.write(`Config saved to ${savedPath}\n`);
+    } catch (error) {
+      process.stderr.write(`Failed to save config: ${error.message}\n`);
+      process.exitCode = 1;
+    }
+    return;
+  }
 
   try {
     const {
@@ -209,13 +629,15 @@ async function main(argv = process.argv.slice(2)) {
       uiPath: resolvedUi,
       close,
       password: serverPassword,
+      publicUrl,
     } = await startServer({
       uiPath: resolvedUiPath,
-      port: args.port,
-      host: args.host,
+      port: finalPort,
+      host: finalHost,
       workdir: workingDir,
       password: chosenPassword,
       commandOverrides,
+      ngrok: ngrokOptions,
     });
 
     const localAddress = host === '0.0.0.0' ? 'localhost' : host;
@@ -223,6 +645,9 @@ async function main(argv = process.argv.slice(2)) {
     process.stdout.write(`Working directory set to ${workingDir}\n`);
     process.stdout.write(`Listening on http://${localAddress}:${port}\n`);
     process.stdout.write(`Password: ${serverPassword || chosenPassword}\n`);
+    if (publicUrl) {
+      process.stdout.write(`Public URL (ngrok): ${publicUrl}\n`);
+    }
 
     let shuttingDown = false;
     const shutdown = () => {


### PR DESCRIPTION
## Summary
- add optional ngrok tunnel support driven by CLI flags or config file
- read defaults from ~/.terminal-worktree/config.json with CLI overrides
- introduce --save flag to persist effective configuration