### PR TITLE
Add create plan button for prompt modal

### DIFF
--- a/src/api/create-plan.js
+++ b/src/api/create-plan.js
@@ -1,0 +1,122 @@
+import { sendJson } from '../utils/http.js';
+
+const OPENAI_CHAT_COMPLETIONS_URL = 'https://api.openai.com/v1/chat/completions';
+
+const DEVELOPER_MESSAGE = `\`\`\`
+Transform any user message describing a feature request, enhancement, or bug fix into a structured PTCGO-style prompt for Codex. The resulting prompt should instruct Codex to directly implement the described change in code provided or in the target repository context.
+
+Follow this structure strictly:
+
+Persona: Assume the role of a senior full-stack developer working with modern frameworks. You write clean, maintainable code and follow SOLID, DRY, and YAGNI principles.
+
+Task: Implement the feature request, enhancement, or bug fix described by the user.
+
+Steps to Complete Task:
+1. Analyse the user’s description to determine what part of the codebase is affected and what needs to change.
+2. If code is provided, use it as the working context. Otherwise, infer where changes belong.
+3. Write complete, correct, and self-contained code implementing the change.
+4. Include inline documentation and clear commit-style explanations if relevant.
+
+Context / Constraints:
+- Do not add boilerplate or unrelated refactors.
+- Maintain existing coding conventions, folder structure, and architectural boundaries.
+- Use concise, idiomatic, production-grade TypeScript or the language of the provided code.
+
+Goal: Produce the minimal and correct code modification that fulfils the request as described. The result must be ready to paste or commit directly.
+
+Format Output: Provide only the final prompt Codex should act on — no extra commentary or metadata. The output must be plain text starting with 'Implement the following change:' followed by the fully structured Codex instruction.
+\`\`\``;
+
+export function createPlanHandlers({ openaiApiKey } = {}) {
+  async function create(context) {
+    let payload;
+    try {
+      payload = await context.readJsonBody();
+    } catch (error) {
+      sendJson(context.res, 400, { error: error.message });
+      return;
+    }
+
+    const prompt = typeof payload.prompt === 'string' ? payload.prompt : '';
+    if (!prompt.trim()) {
+      sendJson(context.res, 400, { error: 'prompt is required' });
+      return;
+    }
+
+    const apiKey = typeof openaiApiKey === 'string' && openaiApiKey.trim()
+      ? openaiApiKey.trim()
+      : null;
+    if (!apiKey) {
+      sendJson(context.res, 500, { error: 'OpenAI API key is not configured (set openaiApiKey in config.json).' });
+      return;
+    }
+
+    let response;
+    try {
+      // Invoke the OpenAI chat completions endpoint with the mandated system context.
+      response = await fetch(OPENAI_CHAT_COMPLETIONS_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-5',
+          messages: [
+            { role: 'developer', content: DEVELOPER_MESSAGE },
+            { role: 'user', content: prompt },
+          ],
+          reasoning: { effort: 'medium' },
+          verbosity: 'low',
+        }),
+      });
+    } catch (error) {
+      sendJson(context.res, 500, {
+        error: `Failed to reach OpenAI: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      return;
+    }
+
+    if (!response.ok) {
+      let detail = `OpenAI request failed with status ${response.status}`;
+      try {
+        const errorBody = await response.json();
+        if (errorBody && typeof errorBody === 'object') {
+          const message =
+            typeof errorBody.error === 'string'
+              ? errorBody.error
+              : typeof errorBody.message === 'string'
+              ? errorBody.message
+              : null;
+          if (message) {
+            detail = message;
+          }
+        }
+      } catch {
+        // Ignore JSON parse errors for OpenAI error responses.
+      }
+      sendJson(context.res, 502, { error: detail });
+      return;
+    }
+
+    let data;
+    try {
+      data = await response.json();
+    } catch (error) {
+      sendJson(context.res, 502, {
+        error: `Failed to parse OpenAI response: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      return;
+    }
+
+    const plan = data?.choices?.[0]?.message?.content;
+    if (typeof plan !== 'string' || !plan.trim()) {
+      sendJson(context.res, 502, { error: 'OpenAI response did not include a plan.' });
+      return;
+    }
+
+    sendJson(context.res, 200, { plan });
+  }
+
+  return { create };
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -44,6 +44,7 @@ export async function startServer({
     agentCommands,
     automationApiKey,
     branchNameGenerator,
+    openaiApiKey: resolvedOpenAiKey,
   });
 
   const server = http.createServer(async (req, res) => {

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -6,6 +6,7 @@ import { createTerminalHandlers } from '../api/terminal.js';
 import { createWorktreeHandlers } from '../api/worktrees.js';
 import { sendJson, readJsonBody } from '../utils/http.js';
 import { createConfigHandlers } from '../api/config.js';
+import { createPlanHandlers } from '../api/create-plan.js';
 
 export function createRouter({
   authManager,
@@ -13,6 +14,7 @@ export function createRouter({
   agentCommands,
   automationApiKey,
   branchNameGenerator,
+  openaiApiKey,
 }) {
   if (!authManager) {
     throw new Error('authManager is required');
@@ -33,6 +35,7 @@ export function createRouter({
   const worktreeHandlers = createWorktreeHandlers(workdir, branchNameGenerator);
   const terminalHandlers = createTerminalHandlers(workdir);
   const configHandlers = createConfigHandlers(agentCommands);
+  const planHandlers = createPlanHandlers({ openaiApiKey });
 
   const routes = new Map([
     [
@@ -108,6 +111,13 @@ export function createRouter({
       {
         requiresAuth: false,
         handlers: { POST: automationHandlers.launch },
+      },
+    ],
+    [
+      '/api/create-plan',
+      {
+        requiresAuth: true,
+        handlers: { POST: planHandlers.create },
       },
     ],
   ]);


### PR DESCRIPTION
## Summary
- add create plan button within the prompt worktree modal
- send prompt to new backend proxy calling OpenAI with the mandated developer message
- wire config-provided openaiApiKey through router and show plan response inline

## Testing
- not run