### PR TITLE
Persist automation plans to worktrees

### DIFF
--- a/src/core/__tests__/plan-storage.test.js
+++ b/src/core/__tests__/plan-storage.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readdir, readFile, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { savePlanToWorktree } from '../plan-storage.js';
+
+test('savePlanToWorktree writes plan file with formatted timestamp and normalised branch name', async () => {
+  const worktree = await mkdtemp(join(tmpdir(), 'plan-storage-'));
+  try {
+    const clock = () => new Date('2025-10-29T12:34:56.000Z');
+    const result = await savePlanToWorktree({
+      worktreePath: worktree,
+      branch: 'feat/new-feature',
+      planText: 'Line 1\nLine 2',
+      clock,
+    });
+
+    const plansDir = join(worktree, '.plans');
+    const expectedName = '20251029_123456-feat_new-feature.md';
+    const expectedPath = join(plansDir, expectedName);
+
+    assert.equal(result, expectedPath);
+
+    const entries = await readdir(plansDir);
+    assert.deepEqual(entries, [expectedName]);
+
+    const content = await readFile(expectedPath, 'utf8');
+    assert.equal(content, 'Line 1\nLine 2\n');
+  } finally {
+    await rm(worktree, { recursive: true, force: true });
+  }
+});
+
+test('savePlanToWorktree skips blank prompts without writing files', async () => {
+  const worktree = await mkdtemp(join(tmpdir(), 'plan-storage-'));
+  try {
+    const result = await savePlanToWorktree({
+      worktreePath: worktree,
+      branch: 'main',
+      planText: '   ',
+    });
+
+    assert.equal(result, null);
+
+    const plansDir = join(worktree, '.plans');
+    await assert.rejects(() => stat(plansDir), (error) => error && error.code === 'ENOENT');
+  } finally {
+    await rm(worktree, { recursive: true, force: true });
+  }
+});

--- a/src/core/plan-storage.js
+++ b/src/core/plan-storage.js
@@ -1,0 +1,58 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+function formatTimestampPart(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new Error('Invalid date supplied to formatTimestamp');
+  }
+  const iso = date.toISOString();
+  const [datePart, timePart] = iso.split('T');
+  const compactDate = datePart.replace(/-/g, '');
+  const compactTime = timePart.slice(0, 8).replace(/:/g, '');
+  return `${compactDate}_${compactTime}`;
+}
+
+function normaliseBranchName(branch) {
+  const value = typeof branch === 'string' ? branch.trim() : '';
+  if (!value) {
+    throw new Error('Branch name is required');
+  }
+  return value.replace(/[^0-9A-Za-z._-]/g, '_');
+}
+
+function ensureTrailingNewline(text) {
+  return text.endsWith('\n') ? text : `${text}\n`;
+}
+
+export async function savePlanToWorktree({
+  worktreePath,
+  branch,
+  planText,
+  clock = () => new Date(),
+}) {
+  const resolvedWorktreePath = typeof worktreePath === 'string' ? worktreePath.trim() : '';
+  if (!resolvedWorktreePath) {
+    throw new Error('worktreePath is required');
+  }
+  const resolvedPlanText = typeof planText === 'string' ? planText : '';
+  if (!resolvedPlanText.trim()) {
+    return null;
+  }
+
+  const timestamp = formatTimestampPart(clock());
+  const safeBranch = normaliseBranchName(branch);
+  const directory = join(resolvedWorktreePath, '.plans');
+  const filename = `${timestamp}-${safeBranch}.md`;
+  const filePath = join(directory, filename);
+
+  await mkdir(directory, { recursive: true });
+  const content = ensureTrailingNewline(resolvedPlanText);
+  await writeFile(filePath, content, 'utf8');
+  return filePath;
+}
+
+export const _internals = {
+  formatTimestampPart,
+  normaliseBranchName,
+  ensureTrailingNewline,
+};


### PR DESCRIPTION
## Summary
- add plan storage helper that writes plan markdown files under .plans
- persist automation prompts before agent launch without blocking on errors
- add unit coverage for plan storage formatting & blank prompt handling

## Testing
- node --test src/core/__tests__/plan-storage.test.js
- node --test src/api/__tests__/automation.test.js