### PR TITLE
Add repository dashboard metrics view

### DIFF
--- a/src/api/__tests__/repo-dashboard.test.js
+++ b/src/api/__tests__/repo-dashboard.test.js
@@ -1,0 +1,132 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createRepoDashboardHandlers } from '../repo-dashboard.js';
+
+function createContext({ method = 'GET', org, repo } = {}) {
+  const baseUrl = new URL('http://localhost/api/repos/dashboard');
+  if (typeof org !== 'undefined') {
+    baseUrl.searchParams.set('org', org);
+  }
+  if (typeof repo !== 'undefined') {
+    baseUrl.searchParams.set('repo', repo);
+  }
+
+  const res = {
+    statusCode: 0,
+    headers: {},
+    ended: false,
+    body: '',
+    setHeader(name, value) {
+      this.headers[name.toLowerCase()] = value;
+    },
+    end(payload = '') {
+      this.body = payload;
+      this.ended = true;
+    },
+  };
+
+  return {
+    method,
+    url: baseUrl,
+    res,
+  };
+}
+
+test('returns dashboard metrics when repository and github client succeed', async () => {
+  const handlers = createRepoDashboardHandlers('/work', {
+    ensureRepo: async () => ({ repositoryPath: '/work/org/repo/repository' }),
+    worktreeCounter: async () => 5,
+    githubClient: {
+      countOpenPullRequests: async (org, repo) => {
+        assert.equal(org, 'org');
+        assert.equal(repo, 'repo');
+        return 3;
+      },
+      countOpenIssues: async () => 7,
+      countRunningWorkflows: async () => 2,
+    },
+    now: () => new Date('2024-01-01T12:00:00Z'),
+  });
+
+  const context = createContext({ method: 'GET', org: 'org', repo: 'repo' });
+  await handlers.read(context);
+
+  assert.equal(context.res.statusCode, 200);
+  assert.equal(context.res.headers['content-type'], 'application/json; charset=utf-8');
+  assert.equal(context.res.ended, true);
+
+  const payload = JSON.parse(context.res.body);
+  assert.deepEqual(payload, {
+    data: {
+      org: 'org',
+      repo: 'repo',
+      fetchedAt: '2024-01-01T12:00:00.000Z',
+      pullRequests: { open: 3 },
+      issues: { open: 7 },
+      workflows: { running: 2 },
+      worktrees: { local: 5 },
+    },
+  });
+});
+
+test('returns 400 when org or repo are missing', async () => {
+  const handlers = createRepoDashboardHandlers('/work');
+
+  const context = createContext({ method: 'GET' });
+  await handlers.read(context);
+
+  assert.equal(context.res.statusCode, 400);
+  const payload = JSON.parse(context.res.body);
+  assert.equal(payload.error, 'org and repo query parameters are required');
+});
+
+test('returns 404 when repository is missing locally', async () => {
+  const handlers = createRepoDashboardHandlers('/work', {
+    ensureRepo: async () => {
+      throw new Error('Repository not found for org/repo');
+    },
+  });
+
+  const context = createContext({ method: 'GET', org: 'org', repo: 'repo' });
+  await handlers.read(context);
+
+  assert.equal(context.res.statusCode, 404);
+  const payload = JSON.parse(context.res.body);
+  assert.equal(payload.error, 'Repository not found for org/repo');
+});
+
+test('returns 502 on GitHub CLI errors', async () => {
+  const handlers = createRepoDashboardHandlers('/work', {
+    ensureRepo: async () => ({ repositoryPath: '/work/org/repo/repository' }),
+    worktreeCounter: async () => 0,
+    githubClient: {
+      countOpenPullRequests: async () => {
+        throw new Error('GitHub CLI command failed');
+      },
+      countOpenIssues: async () => 0,
+      countRunningWorkflows: async () => 0,
+    },
+  });
+
+  const context = createContext({ method: 'GET', org: 'org', repo: 'repo' });
+  await handlers.read(context);
+
+  assert.equal(context.res.statusCode, 502);
+  const payload = JSON.parse(context.res.body);
+  assert.equal(payload.error, 'GitHub CLI command failed');
+});
+
+test('HEAD requests validate repository and exit without body', async () => {
+  const handlers = createRepoDashboardHandlers('/work', {
+    ensureRepo: async () => ({ repositoryPath: '/path' }),
+  });
+
+  const context = createContext({ method: 'HEAD', org: 'org', repo: 'repo' });
+  await handlers.read(context);
+
+  assert.equal(context.res.statusCode, 200);
+  assert.equal(context.res.body, '');
+  assert.equal(context.res.ended, true);
+});
+

--- a/src/api/repo-dashboard.js
+++ b/src/api/repo-dashboard.js
@@ -1,0 +1,68 @@
+import { ensureRepository, countLocalWorktrees } from '../core/git.js';
+import { createGithubClient } from '../core/github.js';
+import { sendJson } from '../utils/http.js';
+
+export function createRepoDashboardHandlers(workdir, overrides = {}) {
+  const {
+    githubClient = createGithubClient(),
+    ensureRepo = ensureRepository,
+    worktreeCounter = countLocalWorktrees,
+    now = () => new Date(),
+  } = overrides;
+
+  async function read(context) {
+    const org = context.url.searchParams.get('org')?.trim() || '';
+    const repo = context.url.searchParams.get('repo')?.trim() || '';
+
+    if (!org || !repo) {
+      sendJson(context.res, 400, { error: 'org and repo query parameters are required' });
+      return;
+    }
+
+    let repositoryPath;
+    try {
+      ({ repositoryPath } = await ensureRepo(workdir, org, repo));
+    } catch (error) {
+      const message = error?.message || 'Repository not found';
+      const statusCode = message.includes('not found') ? 404 : 500;
+      sendJson(context.res, statusCode, { error: message });
+      return;
+    }
+
+    if (context.method === 'HEAD') {
+      context.res.statusCode = 200;
+      context.res.setHeader('Cache-Control', 'no-store');
+      context.res.end();
+      return;
+    }
+
+    try {
+      const [openPullRequests, openIssues, runningWorkflows] = await Promise.all([
+        githubClient.countOpenPullRequests(org, repo),
+        githubClient.countOpenIssues(org, repo),
+        githubClient.countRunningWorkflows(org, repo),
+      ]);
+
+      const worktreeCount = await worktreeCounter(repositoryPath, { includeMain: false });
+      const fetchedAt = now().toISOString();
+
+      sendJson(context.res, 200, {
+        data: {
+          org,
+          repo,
+          fetchedAt,
+          pullRequests: { open: openPullRequests },
+          issues: { open: openIssues },
+          workflows: { running: runningWorkflows },
+          worktrees: { local: worktreeCount },
+        },
+      });
+    } catch (error) {
+      const message = error?.message || 'Failed to load repository dashboard metrics';
+      sendJson(context.res, 502, { error: message });
+    }
+  }
+
+  return { read };
+}
+

--- a/src/core/git.js
+++ b/src/core/git.js
@@ -41,6 +41,22 @@ export async function listWorktrees(repositoryPath) {
   }
 }
 
+export async function countLocalWorktrees(
+  repositoryPath,
+  { includeMain = false } = {},
+) {
+  const worktrees = await listWorktrees(repositoryPath);
+  return worktrees.reduce((total, entry) => {
+    if (!entry || typeof entry.branch !== 'string') {
+      return total;
+    }
+    if (!includeMain && entry.branch === 'main') {
+      return total;
+    }
+    return total + 1;
+  }, 0);
+}
+
 export function parseRepositoryUrl(input) {
   if (typeof input !== 'string' || !input.trim()) {
     throw new Error('Repository URL is required');

--- a/src/core/github.js
+++ b/src/core/github.js
@@ -1,0 +1,114 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_BUFFER = 1024 * 1024;
+
+function createGithubError(message, cause) {
+  const error = new Error(message);
+  if (cause) {
+    error.cause = cause;
+  }
+  return error;
+}
+
+function normaliseRepo(org, repo) {
+  const trimmedOrg = typeof org === 'string' ? org.trim() : '';
+  const trimmedRepo = typeof repo === 'string' ? repo.trim() : '';
+  if (!trimmedOrg || !trimmedRepo) {
+    throw createGithubError('Organisation and repository are required');
+  }
+  return { repoSlug: `${trimmedOrg}/${trimmedRepo}`, org: trimmedOrg, repo: trimmedRepo };
+}
+
+function parseJsonArray(payload, contextMessage) {
+  const text = typeof payload === 'string' ? payload.trim() : '';
+  if (!text) {
+    return [];
+  }
+  try {
+    const data = JSON.parse(text);
+    if (Array.isArray(data)) {
+      return data;
+    }
+  } catch (error) {
+    throw createGithubError(contextMessage, error);
+  }
+  throw createGithubError(contextMessage);
+}
+
+async function runGh(args, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  try {
+    const { stdout } = await execFileAsync('gh', args, {
+      timeout: timeoutMs,
+      maxBuffer: DEFAULT_MAX_BUFFER,
+    });
+    return typeof stdout === 'string' ? stdout : '';
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw createGithubError('GitHub CLI (gh) is not installed or not available on PATH', error);
+    }
+    if (error?.code === 'ETIMEDOUT' || error?.signal === 'SIGTERM' || error?.killed) {
+      throw createGithubError('GitHub CLI command timed out', error);
+    }
+    const stderr = typeof error?.stderr === 'string' ? error.stderr.trim() : '';
+    const stdout = typeof error?.stdout === 'string' ? error.stdout.trim() : '';
+    const message = stderr || stdout || error?.message || 'GitHub CLI command failed';
+    throw createGithubError(message, error);
+  }
+}
+
+export function createGithubClient({ timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  async function countOpenPullRequests(org, repo) {
+    const { repoSlug } = normaliseRepo(org, repo);
+    const stdout = await runGh(
+      ['pr', 'list', '--repo', repoSlug, '--state', 'open', '--json', 'number', '--limit', '100'],
+      { timeoutMs },
+    );
+    return parseJsonArray(stdout, 'Unexpected response when listing pull requests').length;
+  }
+
+  async function countOpenIssues(org, repo) {
+    const { repoSlug } = normaliseRepo(org, repo);
+    const stdout = await runGh(
+      ['issue', 'list', '--repo', repoSlug, '--state', 'open', '--json', 'number', '--limit', '100'],
+      { timeoutMs },
+    );
+    return parseJsonArray(stdout, 'Unexpected response when listing issues').length;
+  }
+
+  async function countRunningWorkflows(org, repo) {
+    const { repoSlug } = normaliseRepo(org, repo);
+    const statuses = ['in_progress', 'queued'];
+    const results = await Promise.all(
+      statuses.map(async (status) => {
+        const stdout = await runGh(
+          [
+            'run',
+            'list',
+            '--repo',
+            repoSlug,
+            '--status',
+            status,
+            '--json',
+            'databaseId,status,workflowName',
+            '--limit',
+            '100',
+          ],
+          { timeoutMs },
+        );
+        return parseJsonArray(stdout, 'Unexpected response when listing workflow runs').length;
+      }),
+    );
+    return results.reduce((total, value) => total + value, 0);
+  }
+
+  return {
+    countOpenPullRequests,
+    countOpenIssues,
+    countRunningWorkflows,
+  };
+}
+

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -1,6 +1,7 @@
 import { createAuthHandlers } from '../api/auth.js';
 import { createAutomationHandlers } from '../api/automation.js';
 import { createRepoHandlers } from '../api/repos.js';
+import { createRepoDashboardHandlers } from '../api/repo-dashboard.js';
 import { createSessionHandlers } from '../api/sessions.js';
 import { createTerminalHandlers } from '../api/terminal.js';
 import { createWorktreeHandlers } from '../api/worktrees.js';
@@ -33,6 +34,7 @@ export function createRouter({
     planService,
   });
   const repoHandlers = createRepoHandlers(workdir);
+  const repoDashboardHandlers = createRepoDashboardHandlers(workdir);
   const sessionHandlers = createSessionHandlers(workdir);
   const worktreeHandlers = createWorktreeHandlers(workdir, branchNameGenerator);
   const terminalHandlers = createTerminalHandlers(workdir);
@@ -72,6 +74,13 @@ export function createRouter({
           POST: repoHandlers.create,
           DELETE: repoHandlers.destroy,
         },
+      },
+    ],
+    [
+      '/api/repos/dashboard',
+      {
+        requiresAuth: true,
+        handlers: { GET: repoDashboardHandlers.read, HEAD: repoDashboardHandlers.read },
       },
     ],
     [

--- a/ui/src/components/RepositoryDashboard.jsx
+++ b/ui/src/components/RepositoryDashboard.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+const { createElement: h } = React;
+
+export default function RepositoryDashboard({
+  repository,
+  data,
+  loading = false,
+  error = null,
+}) {
+  const metrics = [
+    {
+      key: 'pullRequests',
+      label: 'Open Pull Requests',
+      value:
+        typeof data?.pullRequests?.open === 'number' ? data.pullRequests.open : null,
+      description: 'Pending reviews and merges',
+    },
+    {
+      key: 'issues',
+      label: 'Open Issues',
+      value: typeof data?.issues?.open === 'number' ? data.issues.open : null,
+      description: 'Outstanding bugs and tasks',
+    },
+    {
+      key: 'workflows',
+      label: 'Running Workflows',
+      value:
+        typeof data?.workflows?.running === 'number'
+          ? data.workflows.running
+          : null,
+      description: 'Active GitHub Actions runs',
+    },
+    {
+      key: 'worktrees',
+      label: 'Local Worktrees',
+      value:
+        typeof data?.worktrees?.local === 'number' ? data.worktrees.local : null,
+      description: 'Accessible development branches (excluding main)',
+    },
+  ];
+
+  const repoLabel = repository ? `${repository.org}/${repository.repo}` : '';
+
+  return h(
+    'div',
+    { className: 'flex flex-col gap-4 min-h-0 h-full' },
+    repoLabel
+      ? h(
+          'p',
+          { className: 'text-xs text-neutral-500 uppercase tracking-wide' },
+          repoLabel,
+        )
+      : null,
+    error
+      ? h(
+          'div',
+          {
+            className:
+              'text-xs text-amber-200 bg-amber-500/10 border border-amber-500/40 rounded-md px-3 py-2',
+            role: 'status',
+          },
+          error,
+        )
+      : null,
+    h(
+      'div',
+      {
+        className:
+          'grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 content-start',
+      },
+      metrics.map((metric) =>
+        h(
+          'div',
+          {
+            key: metric.key,
+            className:
+              'rounded-lg border border-neutral-800 bg-neutral-925/90 px-4 py-5 flex flex-col gap-2',
+          },
+          h(
+            'p',
+            { className: 'text-xs uppercase tracking-wide text-neutral-500' },
+            metric.label,
+          ),
+          h(
+            'p',
+            { className: 'text-3xl font-semibold text-neutral-100' },
+            metric.value === null ? '—' : metric.value,
+          ),
+          metric.description
+            ? h('p', { className: 'text-xs text-neutral-500' }, metric.description)
+            : null,
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- add backend GitHub CLI wrapper and /api/repos/dashboard endpoint
- surface repository dashboard UI with auto polling and manual refresh
- make sidebar main branch open the dashboard and share GitHub quick links

## Testing
- node --test src/api/__tests__/repo-dashboard.test.js
- npm run build