### PR TITLE
Add GitHub issues feed and automated plans

### DIFF
--- a/.plans/20251102_132401-feature_repo-dashboard-display-open-issues-plan.md
+++ b/.plans/20251102_132401-feature_repo-dashboard-display-open-issues-plan.md
@@ -1,0 +1,38 @@
+The 'dashboard' for a repo (when you click 'main' instead of a worktree) should list all the current open issues for that repository. It should get this information from the gh command in the same way we currently get the count' of issues. It should show the title, the tags, and the date it was opened. There should be 2 buttons next to each issue, one should directly open the issue in Github (in a new tab), the other should create a 'plan' using the following prompt (in the same default llm that the user uses for creating branches and other plans) and load it into the standard 'create from prompt' modal.
+
+The prompt is as follows (please use this EXACT prompt), replacing <ISSUE_NUMBER> with the issue number chosen.
+
+```
+Using the gh command, load the specified GitHub issue and produce a structured plan to resolve or implement it.
+
+1. **Load the issue context**
+   - Retrieve the issue and its comments using:
+     `gh issue view <ISSUE_NUMBER> --comments --json title,body,comments,author,url`
+   - Parse and analyse:
+       • The main issue description and intent.  
+       • All comments and discussion for clarifications or context.  
+       • Any related links, dependencies, or blockers.
+
+2. **Analyse and understand**
+   - Determine the core objective or bug to fix.  
+   - Identify the affected components, modules, or systems.  
+   - Extract any proposed solutions or developer notes.  
+   - Spot missing information or ambiguities that require assumption or clarification.
+
+3. **Generate a plan of action**
+   - Draft a clear, technical, and step-by-step plan including:
+       • **Summary:** One-sentence goal of the issue.  
+       • **Analysis:** Understanding of the root cause or feature requirements.  
+       • **Implementation Plan:** Ordered list of code changes, refactors, or new files needed.  
+       • **Testing/Validation:** How to verify success.  
+       • **Potential Risks / Edge Cases.**  
+       • **Estimated Effort / Time.**
+
+4. **Present and confirm**
+   - Output the full plan directly into this chat.  
+   - Ask:  
+     “Would you like me to start working on this now?”  
+   - Wait for confirmation before taking any further automated action.
+
+Ensure the plan is specific, technically sound, and ready for execution.
+```

--- a/src/api/__tests__/repo-dashboard.test.js
+++ b/src/api/__tests__/repo-dashboard.test.js
@@ -44,6 +44,19 @@ test('returns dashboard metrics when repository and github client succeed', asyn
         return 3;
       },
       countOpenIssues: async () => 7,
+      listOpenIssues: async (org, repo) => {
+        assert.equal(org, 'org');
+        assert.equal(repo, 'repo');
+        return [
+          {
+            number: 12,
+            title: 'Fix dashboard layout',
+            createdAt: '2023-12-31T10:00:00.000Z',
+            labels: ['bug', 'frontend'],
+            url: 'https://github.com/org/repo/issues/12',
+          },
+        ];
+      },
       countRunningWorkflows: async () => 2,
     },
     now: () => new Date('2024-01-01T12:00:00Z'),
@@ -63,7 +76,18 @@ test('returns dashboard metrics when repository and github client succeed', asyn
       repo: 'repo',
       fetchedAt: '2024-01-01T12:00:00.000Z',
       pullRequests: { open: 3 },
-      issues: { open: 7 },
+      issues: {
+        open: 7,
+        items: [
+          {
+            number: 12,
+            title: 'Fix dashboard layout',
+            createdAt: '2023-12-31T10:00:00.000Z',
+            labels: ['bug', 'frontend'],
+            url: 'https://github.com/org/repo/issues/12',
+          },
+        ],
+      },
       workflows: { running: 2 },
       worktrees: { local: 5 },
     },
@@ -105,6 +129,7 @@ test('returns 502 on GitHub CLI errors', async () => {
         throw new Error('GitHub CLI command failed');
       },
       countOpenIssues: async () => 0,
+      listOpenIssues: async () => [],
       countRunningWorkflows: async () => 0,
     },
   });
@@ -129,4 +154,3 @@ test('HEAD requests validate repository and exit without body', async () => {
   assert.equal(context.res.body, '');
   assert.equal(context.res.ended, true);
 });
-

--- a/src/api/create-plan.js
+++ b/src/api/create-plan.js
@@ -19,6 +19,10 @@ export function createPlanHandlers({ planService: providedPlanService } = {}) {
       return;
     }
 
+    const rawPrompt = payload && typeof payload.rawPrompt === 'boolean' ? payload.rawPrompt : false;
+    const dangerousMode =
+      payload && typeof payload.dangerousMode === 'boolean' ? payload.dangerousMode : false;
+
     if (!planService || !planService.isConfigured) {
       sendJson(context.res, 500, {
         error:
@@ -58,7 +62,9 @@ export function createPlanHandlers({ planService: providedPlanService } = {}) {
 
     let planText;
     try {
-      const options = commandCwd ? { prompt, cwd: commandCwd } : { prompt };
+      const options = commandCwd
+        ? { prompt, cwd: commandCwd, rawPrompt, dangerousMode }
+        : { prompt, rawPrompt, dangerousMode };
       planText = await planService.createPlanText(options);
     } catch (error) {
       if (error instanceof Error && error.message === 'prompt is required') {

--- a/src/api/repo-dashboard.js
+++ b/src/api/repo-dashboard.js
@@ -37,9 +37,10 @@ export function createRepoDashboardHandlers(workdir, overrides = {}) {
     }
 
     try {
-      const [openPullRequests, openIssues, runningWorkflows] = await Promise.all([
+      const [openPullRequests, openIssues, openIssueDetails, runningWorkflows] = await Promise.all([
         githubClient.countOpenPullRequests(org, repo),
         githubClient.countOpenIssues(org, repo),
+        githubClient.listOpenIssues(org, repo),
         githubClient.countRunningWorkflows(org, repo),
       ]);
 
@@ -52,7 +53,7 @@ export function createRepoDashboardHandlers(workdir, overrides = {}) {
           repo,
           fetchedAt,
           pullRequests: { open: openPullRequests },
-          issues: { open: openIssues },
+          issues: { open: openIssues, items: openIssueDetails },
           workflows: { running: runningWorkflows },
           worktrees: { local: worktreeCount },
         },
@@ -65,4 +66,3 @@ export function createRepoDashboardHandlers(workdir, overrides = {}) {
 
   return { read };
 }
-

--- a/ui/src/components/RepositoryDashboard.jsx
+++ b/ui/src/components/RepositoryDashboard.jsx
@@ -1,11 +1,49 @@
 import React from 'react';
+
 const { createElement: h } = React;
+
+function formatIssueDate(value) {
+  if (!value) {
+    return 'Opened date unavailable';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Opened date unavailable';
+  }
+  return `Opened ${date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })}`;
+}
+
+function renderIssueLabels(labels) {
+  if (!Array.isArray(labels) || labels.length === 0) {
+    return null;
+  }
+  return h(
+    'div',
+    { className: 'flex flex-wrap gap-1' },
+    labels.map((label) =>
+      h(
+        'span',
+        {
+          key: label,
+          className:
+            'rounded-full border border-neutral-700 bg-neutral-900 px-2 py-[2px] text-[11px] text-neutral-300',
+        },
+        label,
+      ),
+    ),
+  );
+}
 
 export default function RepositoryDashboard({
   repository,
   data,
   loading = false,
   error = null,
+  onCreateIssuePlan,
 }) {
   const metrics = [
     {
@@ -25,9 +63,7 @@ export default function RepositoryDashboard({
       key: 'workflows',
       label: 'Running Workflows',
       value:
-        typeof data?.workflows?.running === 'number'
-          ? data.workflows.running
-          : null,
+        typeof data?.workflows?.running === 'number' ? data.workflows.running : null,
       description: 'Active GitHub Actions runs',
     },
     {
@@ -40,6 +76,9 @@ export default function RepositoryDashboard({
   ];
 
   const repoLabel = repository ? `${repository.org}/${repository.repo}` : '';
+  const issues = Array.isArray(data?.issues?.items) ? data.issues.items : [];
+  const issueCount = typeof data?.issues?.open === 'number' ? data.issues.open : null;
+  const canCreatePlans = typeof onCreateIssuePlan === 'function';
 
   return h(
     'div',
@@ -65,8 +104,7 @@ export default function RepositoryDashboard({
     h(
       'div',
       {
-        className:
-          'grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 content-start',
+        className: 'grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 content-start',
       },
       metrics.map((metric) =>
         h(
@@ -91,6 +129,107 @@ export default function RepositoryDashboard({
             : null,
         ),
       ),
+    ),
+    h(
+      'div',
+      { className: 'space-y-3' },
+      h(
+        'div',
+        { className: 'flex items-center justify-between gap-2' },
+        h('p', { className: 'text-sm font-medium text-neutral-200' }, 'Open Issues'),
+        issueCount !== null
+          ? h('span', { className: 'text-xs text-neutral-400' }, `${issueCount} open`)
+          : null,
+      ),
+      loading && issues.length === 0
+        ? h(
+            'div',
+            {
+              className:
+                'rounded-lg border border-neutral-800 bg-neutral-925/90 px-4 py-6 text-sm text-neutral-400',
+            },
+            'Loading open issues…',
+          )
+        : null,
+      !loading && issues.length === 0
+        ? h(
+            'div',
+            {
+              className:
+                'rounded-lg border border-neutral-800 bg-neutral-925/90 px-4 py-6 text-sm text-neutral-400',
+            },
+            'No open issues found.',
+          )
+        : null,
+      issues.length > 0
+        ? h(
+            'div',
+            {
+              className:
+                'space-y-2 rounded-lg border border-neutral-800 bg-neutral-925/90 p-4 max-h-[50vh] overflow-y-auto',
+            },
+            issues.map((issue, index) => {
+              const key =
+                typeof issue?.number === 'number'
+                  ? `issue-${issue.number}`
+                  : typeof issue?.title === 'string' && issue.title
+                  ? `issue-${index}-${issue.title}`
+                  : `issue-${index}`;
+              const issueUrl =
+                issue && typeof issue.url === 'string' && issue.url
+                  ? issue.url
+                  : repository
+                  ? `https://github.com/${repository.org}/${repository.repo}/issues/${issue?.number ?? ''}`
+                  : '#';
+              return h(
+                'article',
+                {
+                  key,
+                  className:
+                    'rounded-md border border-neutral-800 bg-neutral-950/70 px-3 py-3 text-sm text-neutral-200 space-y-2',
+                },
+                h(
+                  'div',
+                  { className: 'flex flex-col gap-1' },
+                  h(
+                    'p',
+                    { className: 'text-sm font-semibold text-neutral-100 truncate' },
+                    `#${issue?.number ?? '—'} ${issue?.title || 'Untitled issue'}`,
+                  ),
+                  h('p', { className: 'text-xs text-neutral-400' }, formatIssueDate(issue?.createdAt)),
+                ),
+                renderIssueLabels(issue?.labels),
+                h(
+                  'div',
+                  { className: 'flex flex-wrap gap-2' },
+                  h(
+                    'a',
+                    {
+                      href: issueUrl,
+                      target: '_blank',
+                      rel: 'noreferrer',
+                      className:
+                        'inline-flex items-center justify-center gap-2 rounded-md border border-neutral-700 bg-neutral-925 px-3 py-1 text-xs text-neutral-200 transition-colors hover:bg-neutral-900',
+                    },
+                    'Open on GitHub',
+                  ),
+                  canCreatePlans
+                    ? h(
+                        'button',
+                        {
+                          type: 'button',
+                          onClick: () => onCreateIssuePlan(issue, repository),
+                          className:
+                            'inline-flex items-center justify-center gap-2 rounded-md border border-emerald-700/60 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200 transition-colors hover:bg-emerald-500/20',
+                        },
+                        'Create Plan',
+                      )
+                    : null,
+                ),
+              );
+            }),
+          )
+        : null,
     ),
   );
 }


### PR DESCRIPTION
## Summary
- list open issues on repository dashboards with metadata and actions
- generate issue-driven plans via dangerous-mode Codex prompt without extra wrapping
- support raw prompt passthrough in plan service and ensure tests cover new CLI options