### PR TITLE
Modularise automation API handling into dedicated services

### DIFF
--- a/src/core/automation/__tests__/branch.test.js
+++ b/src/core/automation/__tests__/branch.test.js
@@ -1,0 +1,93 @@
+import { describe, test, expect } from 'bun:test';
+import { resolveBranchName } from '../branch.js';
+import { AutomationRequestError } from '../request-validation.js';
+
+describe('branch.resolveBranchName', () => {
+  test('sanitises provided worktree descriptor', async () => {
+    const result = await resolveBranchName({
+      worktreeInput: 'Feature / Login Revamp',
+      branchNameGenerator: null,
+      prompt: 'ignored',
+      org: 'acme',
+      repo: 'web',
+      defaultBranches: {
+        overrides: { 'acme/web': 'develop' },
+      },
+    });
+
+    expect(result.branch).toBe('feature/login-revamp');
+    expect(result.defaultBranchOverride).toBe('develop');
+    expect(result.source).toBe('worktree');
+  });
+
+  test('throws when worktree descriptor is invalid', async () => {
+    await expect(
+      resolveBranchName({
+        worktreeInput: 'invalid',
+        branchNameGenerator: null,
+        prompt: 'ignored',
+        org: 'acme',
+        repo: 'app',
+      }),
+    ).rejects.toBeInstanceOf(AutomationRequestError);
+  });
+
+  test('throws when branch generator is not configured and worktree omitted', async () => {
+    const error = await resolveBranchName({
+      worktreeInput: '',
+      branchNameGenerator: null,
+      prompt: 'Implement feature',
+      org: 'acme',
+      repo: 'api',
+    }).catch((err) => err);
+
+    expect(error).toBeInstanceOf(AutomationRequestError);
+    expect(error.status).toBe(503);
+  });
+
+  test('delegates to branch generator when worktree is missing', async () => {
+    const branchNameGenerator = {
+      isConfigured: true,
+      async generateBranchName({ prompt, org, repo }) {
+        expect(prompt).toBe('Reduce latency');
+        expect(org).toBe('acme');
+        expect(repo).toBe('infra');
+        return 'opt/perf-updates';
+      },
+    };
+
+    const result = await resolveBranchName({
+      worktreeInput: '',
+      branchNameGenerator,
+      prompt: 'Reduce latency',
+      org: 'acme',
+      repo: 'infra',
+      defaultBranches: { global: 'main' },
+    });
+
+    expect(result.branch).toBe('opt/perf-updates');
+    expect(result.defaultBranchOverride).toBe('main');
+    expect(result.source).toBe('generator');
+  });
+
+  test('wraps branch generator failures as AutomationRequestError', async () => {
+    const branchNameGenerator = {
+      isConfigured: true,
+      async generateBranchName() {
+        throw new Error('LLM offline');
+      },
+    };
+
+    const error = await resolveBranchName({
+      worktreeInput: '',
+      branchNameGenerator,
+      prompt: 'Fix tests',
+      org: 'acme',
+      repo: 'cli',
+    }).catch((err) => err);
+
+    expect(error).toBeInstanceOf(AutomationRequestError);
+    expect(error.status).toBe(500);
+    expect(error.message).toBe('LLM offline');
+  });
+});

--- a/src/core/automation/__tests__/git-orchestration.test.js
+++ b/src/core/automation/__tests__/git-orchestration.test.js
@@ -1,0 +1,103 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  ensureRepositoryReady,
+  ensureWorktreeReady,
+  refreshRepositoryViews,
+  createGitOrchestrator,
+} from '../git-orchestration.js';
+
+describe('git-orchestration', () => {
+  test('ensureRepositoryReady wraps repository helper', async () => {
+    const calls = [];
+    const result = await ensureRepositoryReady({
+      ensureRepositoryExists: async (workdir, org, repo) => {
+        calls.push({ workdir, org, repo });
+        return { repositoryPath: '/repos/org/repo', cloned: true };
+      },
+      workdir: '/workdir',
+      org: 'acme',
+      repo: 'app',
+    });
+
+    expect(calls).toEqual([{ workdir: '/workdir', org: 'acme', repo: 'app' }]);
+    expect(result).toEqual({
+      repositoryPath: '/repos/org/repo',
+      clonedRepository: true,
+    });
+  });
+
+  test('ensureWorktreeReady wraps worktree helper', async () => {
+    const calls = [];
+    const result = await ensureWorktreeReady({
+      ensureWorktreeExists: async (workdir, org, repo, branch, options) => {
+        calls.push({ workdir, org, repo, branch, options });
+        return { worktreePath: '/repos/org/repo/feature', created: false };
+      },
+      workdir: '/workdir',
+      org: 'acme',
+      repo: 'app',
+      branch: 'feature/test',
+      defaultBranchOverride: 'develop',
+    });
+
+    expect(calls).toEqual([
+      {
+        workdir: '/workdir',
+        org: 'acme',
+        repo: 'app',
+        branch: 'feature/test',
+        options: { defaultBranchOverride: 'develop' },
+      },
+    ]);
+    expect(result).toEqual({
+      worktreePath: '/repos/org/repo/feature',
+      createdWorktree: false,
+    });
+  });
+
+  test('refreshRepositoryViews discovers repos and emits update', async () => {
+    const discoverCalls = [];
+    const emitCalls = [];
+
+    await refreshRepositoryViews({
+      discoverRepositories: async (workdir) => {
+        discoverCalls.push(workdir);
+        return [{ org: 'acme', repo: 'app' }];
+      },
+      emitReposUpdate: (payload) => {
+        emitCalls.push(payload);
+      },
+      workdir: '/workdir',
+    });
+
+    expect(discoverCalls).toEqual(['/workdir']);
+    expect(emitCalls).toEqual([[{ org: 'acme', repo: 'app' }]]);
+  });
+
+  test('createGitOrchestrator injects shared dependencies', async () => {
+    const orchestrator = createGitOrchestrator({
+      ensureRepositoryExists: async () => ({ repositoryPath: '/repo', cloned: false }),
+      ensureWorktreeExists: async () => ({ worktreePath: '/repo/worktree', created: true }),
+      discoverRepositories: async () => ['snapshot'],
+      emitReposUpdate: () => {},
+    });
+
+    const repository = await orchestrator.ensureRepositoryReady({
+      workdir: '/root',
+      org: 'acme',
+      repo: 'service',
+    });
+    const worktree = await orchestrator.ensureWorktreeReady({
+      workdir: '/root',
+      org: 'acme',
+      repo: 'service',
+      branch: 'feature',
+      defaultBranchOverride: 'main',
+    });
+    const refresh = await orchestrator.refreshRepositoryViews({ workdir: '/root' });
+
+    expect(repository).toEqual({ repositoryPath: '/repo', clonedRepository: false });
+    expect(worktree).toEqual({ worktreePath: '/repo/worktree', createdWorktree: true });
+    expect(refresh).toBeUndefined();
+  });
+});

--- a/src/core/automation/__tests__/plan.test.js
+++ b/src/core/automation/__tests__/plan.test.js
@@ -1,0 +1,89 @@
+import { describe, test, expect } from 'bun:test';
+import { generatePlanText } from '../plan.js';
+import { AutomationRequestError } from '../request-validation.js';
+
+describe('plan.generatePlanText', () => {
+  test('returns original prompt when plan is disabled', async () => {
+    const result = await generatePlanText({
+      planEnabled: false,
+      prompt: 'Refactor module',
+      planService: null,
+      repositoryPath: '/tmp/repo',
+    });
+
+    expect(result).toEqual({
+      promptToExecute: 'Refactor module',
+      planGenerated: false,
+    });
+  });
+
+  test('throws when prompt is missing while plan is enabled', async () => {
+    await expect(
+      generatePlanText({
+        planEnabled: true,
+        prompt: '   ',
+        planService: { isConfigured: true },
+        repositoryPath: '/tmp/repo',
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: 'prompt is required when plan is true',
+    });
+  });
+
+  test('throws when plan service is not configured', async () => {
+    await expect(
+      generatePlanText({
+        planEnabled: true,
+        prompt: 'Investigate bug',
+        planService: null,
+        repositoryPath: '/tmp/repo',
+      }),
+    ).rejects.toMatchObject({
+      status: 503,
+      message:
+        'Plan generation is not configured. Configure a local LLM command (set planLlm in config.json).',
+    });
+  });
+
+  test('returns generated plan text when service succeeds', async () => {
+    const planService = {
+      isConfigured: true,
+      async createPlanText({ prompt, cwd }) {
+        expect(prompt).toBe('Add feature');
+        expect(cwd).toBe('/workspace/repo');
+        return 'Plan: 1. Do thing';
+      },
+    };
+
+    const result = await generatePlanText({
+      planEnabled: true,
+      prompt: 'Add feature',
+      planService,
+      repositoryPath: '/workspace/repo',
+    });
+
+    expect(result).toEqual({
+      promptToExecute: 'Plan: 1. Do thing',
+      planGenerated: true,
+    });
+  });
+
+  test('wraps plan service failures', async () => {
+    const planService = {
+      isConfigured: true,
+      async createPlanText() {
+        throw new Error('Service unavailable');
+      },
+    };
+
+    await expect(
+      generatePlanText({
+        planEnabled: true,
+        prompt: 'Handle errors',
+        planService,
+        repositoryPath: '/workspace/repo',
+      }),
+    ).rejects.toBeInstanceOf(AutomationRequestError);
+  });
+});

--- a/src/core/automation/__tests__/request-validation.test.js
+++ b/src/core/automation/__tests__/request-validation.test.js
@@ -1,0 +1,166 @@
+import { describe, test, expect } from 'bun:test';
+import { validateAutomationRequest } from '../request-validation.js';
+
+describe('request-validation', () => {
+  const agentCommands = {
+    codex: 'codex-command',
+    cursor: 'cursor-command',
+    claude: 'claude-command',
+  };
+
+  const buildRequest = (headers = {}) => ({
+    headers,
+  });
+
+  test('returns parsed payload when request is valid', async () => {
+    const req = buildRequest({ 'x-api-key': 'secret' });
+    const payload = {
+      plan: true,
+      prompt: 'Fix login issue',
+      repo: 'acme/webapp',
+      worktree: 'feature/Login Improvements',
+      command: 'codex',
+    };
+
+    const result = await validateAutomationRequest({
+      req,
+      expectedApiKey: 'secret',
+      readJsonBody: async () => payload,
+      agentCommands,
+    });
+
+    expect(result.planEnabled).toBe(true);
+    expect(result.routeLabel).toBe('create-plan');
+    expect(result.prompt).toBe(payload.prompt);
+    expect(result.org).toBe('acme');
+    expect(result.repo).toBe('webapp');
+    expect(result.worktreeInput).toBe('feature/Login Improvements');
+    expect(result.agent).toEqual({ key: 'codex', command: 'codex-command' });
+  });
+
+  test('falls back to bearer token header for API key', async () => {
+    const req = buildRequest({ authorization: 'Bearer SECRET' });
+    const payload = {
+      plan: false,
+      prompt: '',
+      repo: 'acme/app',
+      command: 'cursor',
+    };
+
+    const result = await validateAutomationRequest({
+      req,
+      expectedApiKey: 'SECRET',
+      readJsonBody: async () => payload,
+      agentCommands,
+    });
+
+    expect(result.planEnabled).toBe(false);
+    expect(result.routeLabel).toBe('passthrough');
+    expect(result.agent).toEqual({ key: 'cursor', command: 'cursor-command' });
+  });
+
+  test('throws 503 when automation API key is missing', async () => {
+    const req = buildRequest();
+
+    await expect(
+      validateAutomationRequest({
+        req,
+        expectedApiKey: '',
+        readJsonBody: async () => ({}),
+        agentCommands,
+      }),
+    ).rejects.toMatchObject({
+      status: 503,
+      message: 'Automation API is not configured (missing API key)',
+    });
+  });
+
+  test('throws 401 when provided API key is invalid', async () => {
+    const req = buildRequest({ 'x-api-key': 'wrong' });
+
+    await expect(
+      validateAutomationRequest({
+        req,
+        expectedApiKey: 'secret',
+        readJsonBody: async () => ({}),
+        agentCommands,
+      }),
+    ).rejects.toMatchObject({ status: 401, message: 'Invalid API key' });
+  });
+
+  test('throws 400 when payload JSON cannot be parsed', async () => {
+    const req = buildRequest({ 'x-api-key': 'secret' });
+    const parseError = new Error('Unexpected token');
+
+    await expect(
+      validateAutomationRequest({
+        req,
+        expectedApiKey: 'secret',
+        readJsonBody: async () => {
+          throw parseError;
+        },
+        agentCommands,
+      }),
+    ).rejects.toMatchObject({ status: 400, message: 'Unexpected token', cause: parseError });
+  });
+
+  test('throws 400 when plan flag is not a boolean', async () => {
+    const req = buildRequest({ 'x-api-key': 'secret' });
+
+    await expect(
+      validateAutomationRequest({
+        req,
+        expectedApiKey: 'secret',
+        readJsonBody: async () => ({
+          plan: 'yes',
+          prompt: '',
+          repo: 'acme/service',
+          command: 'claude',
+        }),
+        agentCommands,
+      }),
+    ).rejects.toMatchObject({ status: 400, message: 'plan must be a boolean' });
+  });
+
+  test('throws 400 when repo identifier is invalid', async () => {
+    const req = buildRequest({ 'x-api-key': 'secret' });
+
+    await expect(
+      validateAutomationRequest({
+        req,
+        expectedApiKey: 'secret',
+        readJsonBody: async () => ({
+          plan: false,
+          prompt: '',
+          repo: 'acme',
+          command: 'codex',
+        }),
+        agentCommands,
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: 'repo must be provided in the format "org/repository"',
+    });
+  });
+
+  test('throws 400 when command is missing or unsupported', async () => {
+    const req = buildRequest({ 'x-api-key': 'secret' });
+
+    await expect(
+      validateAutomationRequest({
+        req,
+        expectedApiKey: 'secret',
+        readJsonBody: async () => ({
+          plan: false,
+          prompt: '',
+          repo: 'acme/app',
+          command: 'unknown',
+        }),
+        agentCommands,
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: 'Unsupported command "unknown". Expected codex, cursor, or claude.',
+    });
+  });
+});

--- a/src/core/automation/__tests__/task-runner.test.js
+++ b/src/core/automation/__tests__/task-runner.test.js
@@ -1,0 +1,286 @@
+import { describe, test, expect } from 'bun:test';
+import { runAutomationTask, STEP_IDS } from '../task-runner.js';
+import { AutomationRequestError } from '../request-validation.js';
+
+function createProgressRecorder() {
+  const events = [];
+  return {
+    events,
+    controller: {
+      ensureStep: (id, label) => events.push({ type: 'ensure', id, label }),
+      startStep: (id, payload) => events.push({ type: 'start', id, payload }),
+      completeStep: (id, payload) => events.push({ type: 'complete', id, payload }),
+      skipStep: (id, payload) => events.push({ type: 'skip', id, payload }),
+      failStep: (id, payload) => events.push({ type: 'fail', id, payload }),
+    },
+  };
+}
+
+describe('task-runner', () => {
+  test('runs automation task with plan generation', async () => {
+    const branchCalls = [];
+    const planCalls = [];
+    const repoCalls = [];
+    const worktreeCalls = [];
+    const refreshCalls = [];
+    const agentCalls = [];
+    const metadataUpdates = [];
+    let resultSnapshot = null;
+    const finishSuccessCalls = [];
+    const finishFailureCalls = [];
+
+    let taskPromise = null;
+    const progressRecorder = createProgressRecorder();
+
+    const runTaskImpl = (config, handler) => {
+      expect(config.type).toBe('automation:launch');
+      taskPromise = handler({
+        progress: progressRecorder.controller,
+        updateMetadata(updates) {
+          metadataUpdates.push(updates);
+        },
+        setResult(result) {
+          resultSnapshot = result;
+        },
+      });
+      return { id: 'task-123' };
+    };
+
+    const resolveBranchName = async (params) => {
+      branchCalls.push(params);
+      return { branch: 'feature/generated', defaultBranchOverride: 'develop', source: 'generator' };
+    };
+
+    const generatePlanText = async (input) => {
+      planCalls.push(input);
+      return { promptToExecute: `${input.prompt} :: plan`, planGenerated: true };
+    };
+
+    const gitOrchestrator = {
+      ensureRepositoryReady: async (args) => {
+        repoCalls.push(args);
+        return { repositoryPath: '/repos/acme/web', clonedRepository: false };
+      },
+      ensureWorktreeReady: async (args) => {
+        worktreeCalls.push(args);
+        return { worktreePath: '/repos/acme/web/feature', createdWorktree: true };
+      },
+      refreshRepositoryViews: async (args) => {
+        refreshCalls.push(args);
+      },
+    };
+
+    const launchAgent = async (args) => {
+      agentCalls.push(args);
+      return {
+        pid: 123,
+        sessionId: 'session-1',
+        tmuxSessionName: 'tmux-1',
+        usingTmux: true,
+        createdSession: true,
+      };
+    };
+
+    const { taskId, queuedData } = await runAutomationTask({
+      runTaskImpl,
+      resolveBranchName,
+      generatePlanText,
+      gitOrchestrator,
+      launchAgent,
+      workdir: '/workdir',
+      planEnabled: true,
+      routeLabel: 'create-plan',
+      prompt: 'Improve DX',
+      org: 'acme',
+      repo: 'web',
+      agent: { key: 'codex', command: 'codex-command' },
+      requestId: 'req-1',
+      worktreeInput: '',
+      branchNameGenerator: { isConfigured: true },
+      defaultBranches: { overrides: { 'acme/web': 'develop' } },
+      planService: { isConfigured: true },
+      finishSuccess: (detail) => finishSuccessCalls.push(detail),
+      finishFailure: (message) => finishFailureCalls.push(message),
+      onBranchResolved: () => {},
+    });
+
+    await taskPromise;
+
+    expect(taskId).toBe('task-123');
+    expect(queuedData).toMatchObject({
+      org: 'acme',
+      repo: 'web',
+      branch: 'feature/generated',
+      plan: true,
+      promptRoute: 'create-plan',
+    });
+
+    expect(branchCalls).toHaveLength(1);
+    expect(branchCalls[0]).toMatchObject({
+      prompt: 'Improve DX',
+      org: 'acme',
+      repo: 'web',
+    });
+
+    expect(planCalls).toHaveLength(1);
+    expect(planCalls[0]).toMatchObject({
+      prompt: 'Improve DX',
+      repositoryPath: '/repos/acme/web',
+    });
+
+    expect(repoCalls).toEqual([{ workdir: '/workdir', org: 'acme', repo: 'web' }]);
+    expect(worktreeCalls).toEqual([
+      {
+        workdir: '/workdir',
+        org: 'acme',
+        repo: 'web',
+        branch: 'feature/generated',
+        defaultBranchOverride: 'develop',
+      },
+    ]);
+    expect(refreshCalls).toEqual([{ workdir: '/workdir' }]);
+
+    expect(agentCalls).toEqual([
+      {
+        command: 'codex-command',
+        workdir: '/workdir',
+        org: 'acme',
+        repo: 'web',
+        branch: 'feature/generated',
+        prompt: 'Improve DX :: plan',
+      },
+    ]);
+
+    expect(resultSnapshot).toMatchObject({
+      org: 'acme',
+      repo: 'web',
+      branch: 'feature/generated',
+      plan: true,
+      agent: 'codex',
+      automationRequestId: 'req-1',
+      terminalSessionCreated: true,
+    });
+
+    expect(metadataUpdates[0]).toEqual({ status: 'running' });
+    expect(metadataUpdates.at(-1)).toEqual({ status: 'succeeded' });
+
+    expect(finishSuccessCalls).toEqual(['acme/web#feature/generated']);
+    expect(finishFailureCalls).toHaveLength(0);
+
+    const skipEvents = progressRecorder.events.filter((event) => event.type === 'skip');
+    expect(skipEvents).toHaveLength(0);
+  });
+
+  test('skips plan step when plan is disabled', async () => {
+    const progressRecorder = createProgressRecorder();
+    let taskPromise = null;
+    const runTaskImpl = (_config, handler) => {
+      taskPromise = handler({
+        progress: progressRecorder.controller,
+        updateMetadata() {},
+        setResult() {},
+      });
+      return { id: 'task-2' };
+    };
+
+    const resolveBranchName = async () => ({
+      branch: 'feature/from-worktree',
+      defaultBranchOverride: undefined,
+      source: 'worktree',
+    });
+
+    const gitOrchestrator = {
+      ensureRepositoryReady: async () => ({
+        repositoryPath: '/repo',
+        clonedRepository: false,
+      }),
+      ensureWorktreeReady: async () => ({
+        worktreePath: '/repo/feature',
+        createdWorktree: false,
+      }),
+      refreshRepositoryViews: async () => {},
+    };
+
+    const launchAgent = async () => ({
+      pid: 456,
+      sessionId: 'session-2',
+      tmuxSessionName: null,
+      usingTmux: false,
+      createdSession: false,
+    });
+
+    const generatePlanText = () => {
+      throw new Error('should not be called');
+    };
+
+    const { queuedData } = await runAutomationTask({
+      runTaskImpl,
+      resolveBranchName,
+      generatePlanText,
+      gitOrchestrator,
+      launchAgent,
+      workdir: '/workdir',
+      planEnabled: false,
+      routeLabel: 'passthrough',
+      prompt: '',
+      org: 'acme',
+      repo: 'web',
+      agent: { key: 'cursor', command: 'cursor-command' },
+      requestId: 'req-2',
+      worktreeInput: 'feature/from-worktree',
+      branchNameGenerator: null,
+      defaultBranches: null,
+      planService: null,
+      finishSuccess: () => {},
+      finishFailure: () => {},
+      onBranchResolved: () => {},
+    });
+
+    await taskPromise;
+
+    expect(queuedData.plan).toBe(false);
+    const skipEvents = progressRecorder.events.filter(
+      (event) => event.type === 'skip' && event.id === STEP_IDS.GENERATE_PLAN,
+    );
+    expect(skipEvents).toHaveLength(1);
+  });
+
+  test('propagates resolveBranchName errors', async () => {
+    const runTaskImpl = () => {
+      throw new Error('should not get here');
+    };
+
+    const resolveBranchName = async () => {
+      throw new AutomationRequestError(400, 'Invalid worktree');
+    };
+
+    await expect(
+      runAutomationTask({
+        runTaskImpl,
+        resolveBranchName,
+        generatePlanText: async () => ({ promptToExecute: '', planGenerated: false }),
+        gitOrchestrator: {
+          ensureRepositoryReady: async () => ({}),
+          ensureWorktreeReady: async () => ({}),
+          refreshRepositoryViews: async () => {},
+        },
+        launchAgent: async () => ({}),
+        workdir: '/workdir',
+        planEnabled: true,
+        routeLabel: 'create-plan',
+        prompt: 'Prompt',
+        org: 'acme',
+        repo: 'web',
+        agent: { key: 'codex', command: 'cmd' },
+        requestId: 'req-3',
+        worktreeInput: '',
+        branchNameGenerator: null,
+        defaultBranches: null,
+        planService: null,
+        finishSuccess: () => {},
+        finishFailure: () => {},
+        onBranchResolved: () => {},
+      }),
+    ).rejects.toBeInstanceOf(AutomationRequestError);
+  });
+});

--- a/src/core/automation/branch.js
+++ b/src/core/automation/branch.js
@@ -1,0 +1,53 @@
+import { selectDefaultBranchOverride } from '../default-branch.js';
+import {
+  AutomationRequestError,
+  sanitiseWorktreeDescriptor,
+} from './request-validation.js';
+
+/**
+ * Branch resolution for automation requests, whether supplied by the client or generated.
+ */
+
+export async function resolveBranchName({
+  worktreeInput,
+  branchNameGenerator,
+  prompt,
+  org,
+  repo,
+  defaultBranches,
+}) {
+  const defaultBranchOverride = selectDefaultBranchOverride(defaultBranches, org, repo);
+
+  if (worktreeInput) {
+    const branch = sanitiseWorktreeDescriptor(worktreeInput);
+    return { branch, defaultBranchOverride, source: 'worktree' };
+  }
+
+  if (!branchNameGenerator || !branchNameGenerator.isConfigured) {
+    throw new AutomationRequestError(
+      503,
+      'Branch name generation is not configured. Provide a worktree name or configure a local LLM command (set branchNameLlm in config.json).',
+    );
+  }
+
+  try {
+    const branch = await branchNameGenerator.generateBranchName({
+      prompt,
+      org,
+      repo,
+    });
+
+    if (!branch) {
+      throw new AutomationRequestError(500, 'Failed to determine branch name.');
+    }
+
+    return { branch, defaultBranchOverride, source: 'generator' };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new AutomationRequestError(
+      500,
+      message,
+      error instanceof Error ? error : undefined,
+    );
+  }
+}

--- a/src/core/automation/git-orchestration.js
+++ b/src/core/automation/git-orchestration.js
@@ -1,0 +1,53 @@
+/**
+ * Git/worktree orchestration helpers used by the automation task runner.
+ */
+
+export async function ensureRepositoryReady({
+  ensureRepositoryExists,
+  workdir,
+  org,
+  repo,
+}) {
+  const { repositoryPath, cloned } = await ensureRepositoryExists(workdir, org, repo);
+  return { repositoryPath, clonedRepository: cloned };
+}
+
+export async function ensureWorktreeReady({
+  ensureWorktreeExists,
+  workdir,
+  org,
+  repo,
+  branch,
+  defaultBranchOverride,
+}) {
+  const { worktreePath, created } = await ensureWorktreeExists(workdir, org, repo, branch, {
+    defaultBranchOverride,
+  });
+
+  return { worktreePath, createdWorktree: created };
+}
+
+export async function refreshRepositoryViews({
+  discoverRepositories,
+  emitReposUpdate,
+  workdir,
+}) {
+  const reposSnapshot = await discoverRepositories(workdir);
+  emitReposUpdate(reposSnapshot);
+}
+
+export function createGitOrchestrator({
+  ensureRepositoryExists,
+  ensureWorktreeExists,
+  discoverRepositories,
+  emitReposUpdate,
+}) {
+  return {
+    ensureRepositoryReady: (args) =>
+      ensureRepositoryReady({ ensureRepositoryExists, ...args }),
+    ensureWorktreeReady: (args) =>
+      ensureWorktreeReady({ ensureWorktreeExists, ...args }),
+    refreshRepositoryViews: (args) =>
+      refreshRepositoryViews({ discoverRepositories, emitReposUpdate, ...args }),
+  };
+}

--- a/src/core/automation/plan.js
+++ b/src/core/automation/plan.js
@@ -1,0 +1,43 @@
+import { AutomationRequestError } from './request-validation.js';
+
+/**
+ * Utilities for wrapping optional plan generation prior to launching an automation task.
+ */
+
+export async function generatePlanText({
+  planEnabled,
+  prompt,
+  planService,
+  repositoryPath,
+}) {
+  if (!planEnabled) {
+    return { promptToExecute: prompt, planGenerated: false };
+  }
+
+  if (!prompt.trim()) {
+    throw new AutomationRequestError(400, 'prompt is required when plan is true');
+  }
+
+  if (!planService || !planService.isConfigured) {
+    throw new AutomationRequestError(
+      503,
+      'Plan generation is not configured. Configure a local LLM command (set planLlm in config.json).',
+    );
+  }
+
+  try {
+    const planText = await planService.createPlanText({
+      prompt,
+      cwd: repositoryPath,
+    });
+
+    return { promptToExecute: planText, planGenerated: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new AutomationRequestError(
+      500,
+      message,
+      error instanceof Error ? error : undefined,
+    );
+  }
+}

--- a/src/core/automation/request-validation.js
+++ b/src/core/automation/request-validation.js
@@ -1,0 +1,196 @@
+import { normaliseBranchName } from '../git.js';
+
+/**
+ * Helpers for validating inbound automation API requests and normalising payload data.
+ */
+
+export class AutomationRequestError extends Error {
+  constructor(status, message, cause) {
+    super(message);
+    this.name = 'AutomationRequestError';
+    this.status = status;
+    if (cause) {
+      this.cause = cause;
+    }
+  }
+}
+
+export function extractApiKey(req) {
+  const apiKeyHeader = req.headers?.['x-api-key'];
+  if (typeof apiKeyHeader === 'string' && apiKeyHeader.trim()) {
+    return apiKeyHeader.trim();
+  }
+
+  const authHeader = req.headers?.authorization;
+  if (typeof authHeader === 'string') {
+    const trimmed = authHeader.trim();
+    if (/^bearer\s+/i.test(trimmed)) {
+      return trimmed.replace(/^bearer\s+/i, '').trim();
+    }
+  }
+
+  return '';
+}
+
+export async function parseRequestPayload(readJsonBody) {
+  try {
+    return await readJsonBody();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid JSON payload';
+    throw new AutomationRequestError(400, message, error instanceof Error ? error : undefined);
+  }
+}
+
+export function parsePlanFlag(value) {
+  if (value === undefined) {
+    return true;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  throw new AutomationRequestError(400, 'plan must be a boolean');
+}
+
+export function validatePrompt(rawPrompt) {
+  if (rawPrompt === undefined) {
+    return '';
+  }
+
+  if (typeof rawPrompt !== 'string') {
+    throw new AutomationRequestError(400, 'prompt must be a string');
+  }
+
+  return rawPrompt;
+}
+
+export function parseRepoIdentifier(input) {
+  if (typeof input !== 'string' || !input.trim()) {
+    throw new AutomationRequestError(
+      400,
+      'repo must be provided in the format "org/repository"',
+    );
+  }
+
+  const cleaned = input.trim().replace(/\.git$/i, '');
+  const segments = cleaned.split('/').filter(Boolean);
+
+  if (segments.length !== 2) {
+    throw new AutomationRequestError(
+      400,
+      'repo must be provided in the format "org/repository"',
+    );
+  }
+
+  return { org: segments[0], repo: segments[1] };
+}
+
+export function sanitiseWorktreeDescriptor(worktreeDescriptor) {
+  if (typeof worktreeDescriptor !== 'string' || !worktreeDescriptor.trim()) {
+    throw new AutomationRequestError(400, 'worktree must be provided as "type/title"');
+  }
+
+  const parts = worktreeDescriptor
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length < 2) {
+    throw new AutomationRequestError(
+      400,
+      'worktree must include both type and title separated by "/"',
+    );
+  }
+
+  const slugify = (value) =>
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/gi, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+  const segments = parts.map((part) => {
+    const slug = slugify(part);
+    if (!slug) {
+      throw new AutomationRequestError(
+        400,
+        'worktree name segments must include alphanumeric characters',
+      );
+    }
+    return slug;
+  });
+
+  const branchName = normaliseBranchName(segments.join('/'));
+  if (!branchName) {
+    throw new AutomationRequestError(400, 'Derived branch name is empty');
+  }
+  if (branchName.toLowerCase() === 'main') {
+    throw new AutomationRequestError(400, 'worktree branch "main" is not allowed');
+  }
+
+  return branchName;
+}
+
+export function resolveAgentCommand(agentCommands, requested) {
+  const key = typeof requested === 'string' ? requested.trim().toLowerCase() : '';
+  if (!key) {
+    throw new AutomationRequestError(400, 'command must be one of: codex, cursor, claude');
+  }
+
+  const mapping = {
+    codex: agentCommands?.codexDangerous || agentCommands?.codex,
+    cursor: agentCommands?.cursor,
+    claude: agentCommands?.claudeDangerous || agentCommands?.claude,
+  };
+
+  const command = mapping[key];
+  if (!command) {
+    throw new AutomationRequestError(
+      400,
+      `Unsupported command "${requested}". Expected codex, cursor, or claude.`,
+    );
+  }
+
+  return { key, command };
+}
+
+export async function validateAutomationRequest({
+  req,
+  expectedApiKey,
+  readJsonBody,
+  agentCommands,
+}) {
+  if (!expectedApiKey) {
+    throw new AutomationRequestError(
+      503,
+      'Automation API is not configured (missing API key)',
+    );
+  }
+
+  const providedKey = extractApiKey(req);
+  if (providedKey !== expectedApiKey) {
+    throw new AutomationRequestError(401, 'Invalid API key');
+  }
+
+  const payload = await parseRequestPayload(readJsonBody);
+  const planEnabled = parsePlanFlag(payload.plan);
+  const routeLabel = planEnabled ? 'create-plan' : 'passthrough';
+
+  const prompt = validatePrompt(payload.prompt);
+  const { org, repo } = parseRepoIdentifier(payload.repo);
+
+  const worktreeInput =
+    typeof payload.worktree === 'string' ? payload.worktree.trim() : '';
+
+  const agent = resolveAgentCommand(agentCommands, payload.command);
+
+  return {
+    payload,
+    planEnabled,
+    routeLabel,
+    prompt,
+    org,
+    repo,
+    worktreeInput,
+    agent,
+  };
+}

--- a/src/core/automation/task-runner.js
+++ b/src/core/automation/task-runner.js
@@ -1,0 +1,270 @@
+/**
+ * Coordinates the asynchronous automation launch task, updating task progress and metadata.
+ */
+
+export const TASK_TYPE_AUTOMATION = 'automation:launch';
+
+export const STEP_IDS = Object.freeze({
+  ENSURE_REPO: 'ensure-repository',
+  GENERATE_PLAN: 'generate-plan',
+  ENSURE_WORKTREE: 'ensure-worktree',
+  LAUNCH_AGENT: 'launch-agent',
+  REFRESH_REPOS: 'refresh-repositories',
+});
+
+export const STEP_LABELS = Object.freeze({
+  [STEP_IDS.ENSURE_REPO]: 'Ensure repository',
+  [STEP_IDS.GENERATE_PLAN]: 'Generate plan',
+  [STEP_IDS.ENSURE_WORKTREE]: 'Ensure worktree',
+  [STEP_IDS.LAUNCH_AGENT]: 'Launch agent',
+  [STEP_IDS.REFRESH_REPOS]: 'Refresh repositories',
+});
+
+export async function runAutomationTask({
+  runTaskImpl,
+  resolveBranchName,
+  generatePlanText,
+  gitOrchestrator,
+  launchAgent,
+  workdir,
+  planEnabled,
+  routeLabel,
+  prompt,
+  org,
+  repo,
+  agent,
+  requestId,
+  worktreeInput,
+  branchNameGenerator,
+  defaultBranches,
+  planService,
+  finishSuccess,
+  finishFailure,
+  onBranchResolved,
+}) {
+  if (typeof runTaskImpl !== 'function') {
+    throw new Error('runTask implementation is required');
+  }
+  if (!gitOrchestrator) {
+    throw new Error('git orchestrator is required');
+  }
+
+  const { ensureRepositoryReady, ensureWorktreeReady, refreshRepositoryViews } = gitOrchestrator;
+
+  const { branch, defaultBranchOverride } = await resolveBranchName({
+    worktreeInput,
+    branchNameGenerator,
+    prompt,
+    org,
+    repo,
+    defaultBranches,
+  });
+
+  if (typeof onBranchResolved === 'function') {
+    onBranchResolved(branch);
+  }
+
+  const taskMetadata = {
+    automationRequestId: requestId,
+    planEnabled,
+    promptProvided: Boolean(prompt.trim()),
+    org,
+    repo,
+    branch,
+    command: agent.key,
+    status: 'pending',
+  };
+
+  const { id: taskId } = runTaskImpl(
+    {
+      type: TASK_TYPE_AUTOMATION,
+      title: `Automation launch for ${org}/${repo}`,
+      metadata: taskMetadata,
+    },
+    async ({ progress, setResult, updateMetadata }) => {
+      const finalData = {
+        org,
+        repo,
+        branch,
+        plan: planEnabled,
+        promptRoute: routeLabel,
+        automationRequestId: requestId,
+        agent: agent.key,
+        agentCommand: agent.command,
+        repositoryPath: null,
+        worktreePath: null,
+        clonedRepository: false,
+        createdWorktree: false,
+        pid: null,
+        terminalSessionId: null,
+        terminalSessionCreated: false,
+        tmuxSessionName: null,
+        terminalUsingTmux: false,
+      };
+
+      let currentStep = null;
+      const startStep = (id, message) => {
+        currentStep = id;
+        progress.startStep(id, { label: STEP_LABELS[id], message });
+      };
+      const completeStep = (id, message) => {
+        progress.completeStep(id, { label: STEP_LABELS[id], message });
+        if (currentStep === id) {
+          currentStep = null;
+        }
+      };
+      const failCurrentStep = (message) => {
+        if (!currentStep) {
+          return;
+        }
+        progress.failStep(currentStep, { label: STEP_LABELS[currentStep], message });
+        currentStep = null;
+      };
+
+      progress.ensureStep(STEP_IDS.ENSURE_REPO, STEP_LABELS[STEP_IDS.ENSURE_REPO]);
+      progress.ensureStep(STEP_IDS.GENERATE_PLAN, STEP_LABELS[STEP_IDS.GENERATE_PLAN]);
+      progress.ensureStep(STEP_IDS.ENSURE_WORKTREE, STEP_LABELS[STEP_IDS.ENSURE_WORKTREE]);
+      progress.ensureStep(STEP_IDS.LAUNCH_AGENT, STEP_LABELS[STEP_IDS.LAUNCH_AGENT]);
+      progress.ensureStep(STEP_IDS.REFRESH_REPOS, STEP_LABELS[STEP_IDS.REFRESH_REPOS]);
+
+      updateMetadata({ status: 'running' });
+
+      try {
+        startStep(STEP_IDS.ENSURE_REPO, 'Ensuring repository exists.');
+        const { repositoryPath, clonedRepository } = await ensureRepositoryReady({
+          workdir,
+          org,
+          repo,
+        });
+        finalData.repositoryPath = repositoryPath;
+        finalData.clonedRepository = clonedRepository;
+        updateMetadata({ repositoryPath, clonedRepository });
+        completeStep(
+          STEP_IDS.ENSURE_REPO,
+          clonedRepository ? 'Repository cloned successfully.' : 'Repository is ready.',
+        );
+
+        let effectivePrompt = prompt;
+        if (planEnabled) {
+          startStep(STEP_IDS.GENERATE_PLAN, 'Generating plan text.');
+          try {
+            const planResult = await generatePlanText({
+              planEnabled,
+              prompt,
+              planService,
+              repositoryPath,
+            });
+            effectivePrompt = planResult.promptToExecute;
+            completeStep(STEP_IDS.GENERATE_PLAN, 'Plan generated successfully.');
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            failCurrentStep(message);
+            updateMetadata({ status: 'failed', error: message });
+            throw error instanceof Error ? error : new Error(message);
+          }
+        } else {
+          progress.skipStep(STEP_IDS.GENERATE_PLAN, {
+            label: STEP_LABELS[STEP_IDS.GENERATE_PLAN],
+            message: 'Plan generation disabled for this request.',
+          });
+        }
+
+        startStep(STEP_IDS.ENSURE_WORKTREE, 'Ensuring worktree is available.');
+        const { worktreePath, createdWorktree } = await ensureWorktreeReady({
+          workdir,
+          org,
+          repo,
+          branch,
+          defaultBranchOverride,
+        });
+        finalData.worktreePath = worktreePath;
+        finalData.createdWorktree = createdWorktree;
+        updateMetadata({ worktreePath, createdWorktree });
+        completeStep(
+          STEP_IDS.ENSURE_WORKTREE,
+          createdWorktree ? 'Worktree created successfully.' : 'Worktree already existed.',
+        );
+
+        startStep(STEP_IDS.REFRESH_REPOS, 'Refreshing repository view.');
+        try {
+          await refreshRepositoryViews({ workdir });
+          completeStep(STEP_IDS.REFRESH_REPOS, 'Repository view updated.');
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          failCurrentStep(message);
+          updateMetadata({ status: 'failed', error: message });
+          finishFailure(message, error instanceof Error ? error : undefined);
+          throw error instanceof Error ? error : new Error(message);
+        }
+
+        startStep(STEP_IDS.LAUNCH_AGENT, 'Launching agent command.');
+        const {
+          pid,
+          sessionId,
+          tmuxSessionName,
+          usingTmux,
+          createdSession,
+        } = await launchAgent({
+          command: agent.command,
+          workdir,
+          org,
+          repo,
+          branch,
+          prompt: effectivePrompt,
+        });
+
+        finalData.pid = pid;
+        finalData.terminalSessionId = sessionId;
+        finalData.terminalSessionCreated = createdSession;
+        finalData.tmuxSessionName = tmuxSessionName;
+        finalData.terminalUsingTmux = usingTmux;
+
+        updateMetadata({
+          pid,
+          terminalSessionId: sessionId,
+          terminalSessionCreated: createdSession,
+          tmuxSessionName,
+          terminalUsingTmux: usingTmux,
+        });
+
+        completeStep(STEP_IDS.LAUNCH_AGENT, 'Agent launched successfully.');
+
+        finishSuccess(`${org}/${repo}#${branch}`);
+        updateMetadata({ status: 'succeeded' });
+        setResult(finalData);
+        return finalData;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failCurrentStep(message);
+        updateMetadata({ status: 'failed', error: message });
+        finishFailure(message, error instanceof Error ? error : undefined);
+        if (!(error instanceof Error)) {
+          throw new Error(message);
+        }
+        throw error;
+      }
+    },
+  );
+
+  const queuedData = {
+    org,
+    repo,
+    branch,
+    repositoryPath: null,
+    worktreePath: null,
+    clonedRepository: null,
+    createdWorktree: null,
+    agent: agent.key,
+    agentCommand: agent.command,
+    pid: null,
+    terminalSessionId: null,
+    terminalSessionCreated: false,
+    tmuxSessionName: null,
+    terminalUsingTmux: false,
+    plan: planEnabled,
+    promptRoute: routeLabel,
+    automationRequestId: requestId,
+  };
+
+  return { taskId, queuedData, branch };
+}


### PR DESCRIPTION
## Summary
This change modularises the automation API route so validation, branch resolution, plan generation, git prep, and task orchestration each live in focused services. The existing metrics, logging, and response shapes stay intact, while fresh unit suites document the contract for each component. This should make future automation work faster to reason about for engineers and easier to audit for leadership.

## Technical details
- Introduced `src/core/automation/*` modules for request validation, branch derivation, optional plan generation, git/worktree orchestration, and task execution wiring.
- Reworked `createAutomationHandlers` to inject those services, reuse shared helpers, and keep metric accounting untouched.
- Added Bun-based tests for validation, branch naming, plan handling, git orchestration, and task runner scenarios (success, failure, and disabled-plan paths).

## Risks & mitigations
- Behavioural regressions could arise if injected dependencies drift from previous defaults; unit suites exercise happy and failure paths to catch divergence early.
- Full integration still depends on `node-pty` being rebuilt for Bun; document the native dependency and keep end-to-end smoke checks in mind.

## Breaking changes / Migration
- None.

## Test coverage
- ✅ `bun test src/core/automation/__tests__`
- ⚠️ Full `bun test` currently blocked by the upstream `node-pty` binary built for Node; integration verification should happen after recompiling the dependency.

## Rollback plan
- Revert commit `ef2476a` and redeploy the service to restore the previous automation handler.

## Checklist
- [ ] docs updated
- [ ] dashboards/alerts adjusted
- [ ] migrations applied
