### PR TITLE
Ensure repository init commands run through interactive shells

### DIFF
--- a/src/core/git.js
+++ b/src/core/git.js
@@ -251,9 +251,15 @@ async function runRepositoryInitCommand(repoRoot, worktreePath) {
 
   const candidateShell = typeof process.env.SHELL === 'string' ? process.env.SHELL.trim() : '';
   const shell = candidateShell || '/bin/sh';
+  const shellName = path.basename(shell);
+  const shellArgs = ['-l', '-c', initCommand];
+
+  if (['bash', 'zsh', 'fish'].includes(shellName)) {
+    shellArgs.splice(1, 0, '-i');
+  }
 
   try {
-    await execFileAsync(shell, ['-lc', initCommand], {
+    await execFileAsync(shell, shellArgs, {
       cwd: worktreePath,
       maxBuffer: INIT_COMMAND_MAX_BUFFER,
       env: { ...process.env },


### PR DESCRIPTION
## Summary
Repository initialisation scripts were previously executed in non-interactive shells, so user profile hooks were skipped.
This update detects supported shells and adds interactive login flags so those hooks run consistently.

## Technical details
- fix: derive the shell name, build a reusable argument list, and add `-i` when invoking bash, zsh, or fish
- fix: reuse the computed argument array when invoking `execFileAsync` to keep init logic in one place

## Risks & mitigations
- low: unsupported shells continue to use the existing non-interactive pathway, and `/bin/sh` remains the fallback

## Breaking changes / Migration
- None.

## Test coverage
- No automated tests cover this path; changes verified by reasoning about the shell invocation flow.

## Rollback plan
- Revert commit `c8de043` and redeploy the service.

## Checklist
- [ ] docs updated
- [ ] dashboards/alerts adjusted
- [ ] migrations applied
